### PR TITLE
NPE when reading laz 1.4 file

### DIFF
--- a/src/main/java/com/github/mreutegg/laszip4j/LASExtendedVariableLengthRecord.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/LASExtendedVariableLengthRecord.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Marcel Reutegger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.mreutegg.laszip4j;
+
+import com.github.mreutegg.laszip4j.laslib.LASevlr;
+
+import java.nio.ByteBuffer;
+
+import static com.github.mreutegg.laszip4j.laszip.MyDefs.stringFromByteArray;
+
+/**
+ * A LAS extended variable length header record.
+ */
+public class LASExtendedVariableLengthRecord {
+
+    private final LASevlr evlr;
+
+    LASExtendedVariableLengthRecord(LASevlr evlr) {
+        this.evlr = evlr;
+    }
+
+    /**
+     * @return "Reserved" as an unsigned short (char).
+     */
+    public char getReserved() {
+        return evlr.reserved;
+    }
+
+    /**
+     * @return "User ID" as a String.
+     */
+    public String getUserID() {
+        return stringFromByteArray(evlr.user_id);
+    }
+
+    /**
+     * @return "Record ID" as an unsigned short (char).
+     */
+    public char getRecordID() {
+        return evlr.record_id;
+    }
+
+    /**
+     * @return "Record Length After Header" as an unsigned long
+     */
+    public long getRecordLength() {
+        return evlr.record_length_after_header;
+    }
+
+    /**
+     * @return "Description" as a String.
+     */
+    public String getDescription() {
+        return stringFromByteArray(evlr.description);
+    }
+
+    /**
+     * @return the data of the record as a read-only ByteBuffer.
+     */
+    public ByteBuffer getData() {
+        return ByteBuffer.wrap(evlr.data).asReadOnlyBuffer();
+    }
+
+    /**
+     * @return the data of the record as a String.
+     */
+    public String getDataAsString() {
+        return stringFromByteArray(evlr.data);
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/LASHeader.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/LASHeader.java
@@ -16,6 +16,7 @@
  */
 package com.github.mreutegg.laszip4j;
 
+import com.github.mreutegg.laszip4j.laslib.LASevlr;
 import com.github.mreutegg.laszip4j.laslib.LASheader;
 import com.github.mreutegg.laszip4j.laslib.LASvlr;
 
@@ -306,5 +307,13 @@ public final class LASHeader {
             records.add(new LASVariableLengthRecord(vlr));
         }
         return records.subList(0, getNumberOfVariableLengthRecords());
+    }
+
+    public Iterable<LASExtendedVariableLengthRecord> getExtendedVariableLengthRecords() {
+        List<LASExtendedVariableLengthRecord> records = new ArrayList<>();
+        for (LASevlr vlr : header.evlrs) {
+            records.add(new LASExtendedVariableLengthRecord(vlr));
+        }
+        return records.subList(0, getNumberOfExtendedVariableLengthRecords());
     }
 }

--- a/src/main/java/com/github/mreutegg/laszip4j/laslib/LASreaderLAS.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laslib/LASreaderLAS.java
@@ -855,6 +855,7 @@ public class LASreaderLAS extends LASreader {
 
                     for (i = 0; i < header.number_of_extended_variable_length_records; i++)
                     {
+                        header.evlrs[i] = new LASevlr();
                         // read variable length records variable after variable (to avoid alignment issues)
 
                         try { header.evlrs[i].reserved = stream.get16bitsLE(); } catch (Exception e)

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
@@ -585,8 +585,8 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
             // So scan_direction_flag is at bit 4, and edge_of_flight_line is at bit 5
             // (classification flags are per spec, 4 bits covering bits 0-3)
             
-            int last_flags = (last_item.hasScanFlag(ScanFlag.EdgeOfFlightLine)?1:0 << 5) | 
-                             (last_item.hasScanFlag(ScanFlag.ScanDirection)?1:0 << 4) | 
+            int last_flags = ((last_item.hasScanFlag(ScanFlag.EdgeOfFlightLine)?1:0) << 5) |
+                             ((last_item.hasScanFlag(ScanFlag.ScanDirection)?1:0) << 4) |
                              last_item.getClassificationFlags();
             if (contexts[current_context].m_flags[last_flags] == null)
             {

--- a/src/test/java/com/github/mreutegg/laszip4j/LASReaderTest.java
+++ b/src/test/java/com/github/mreutegg/laszip4j/LASReaderTest.java
@@ -99,7 +99,10 @@ public class LASReaderTest {
         assertEquals("LASF", header.getFileSignature());
         List<LASExtendedVariableLengthRecord> evlrs = StreamSupport.stream(header.getExtendedVariableLengthRecords().spliterator(), false).collect(Collectors.toList());
         assertEquals(header.getNumberOfExtendedVariableLengthRecords(), evlrs.size());
+        assertEquals(0, evlrs.get(0).getReserved());
         assertEquals("copc", evlrs.get(0).getUserID());
+        assertEquals(1000, evlrs.get(0).getRecordID());
+        assertEquals(8896, evlrs.get(0).getRecordLength());
         assertEquals("EPT Hierarchy", evlrs.get(0).getDescription());
         long numPoints = 0;
         for (LASPoint p : reader.getPoints()) {


### PR DESCRIPTION
- Initialize LASevlr for each array entry
- Fix bug in LASreadItemCompressed_POINT14_v3
- Expose LASExtendedVariableLengthRecord in LASHeader
- Add test that reads a laz 1.4 file