### PR TITLE
Resolves issue #65 - treat classification byte as unsigned char

### DIFF
--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v1.java
@@ -164,7 +164,7 @@ public class LASreadItemCompressed_POINT10_v1 extends LASreadItemCompressed {
                     m_classification[last_item.Classification] = dec.createSymbolModel(256);
                     dec.initSymbolModel(m_classification[last_item.Classification]);
                 }
-                last_item.Classification = (byte) dec.decodeSymbol(m_classification[last_item.Classification]);
+                last_item.Classification = (short) dec.decodeSymbol(m_classification[last_item.Classification]);
             }
 
             // decompress the scan_angle_rank ... if it has changed

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v2.java
@@ -146,7 +146,7 @@ public class LASreadItemCompressed_POINT10_v2 extends LASreadItemCompressed {
                     m_classification[last_item.Classification] = dec.createSymbolModel(256);
                     dec.initSymbolModel(m_classification[last_item.Classification]);
                 }
-                last_item.Classification = (byte) dec.decodeSymbol(m_classification[last_item.Classification]);
+                last_item.Classification = (short) dec.decodeSymbol(m_classification[last_item.Classification]);
             }
 
             // decompress the scan_angle_rank ... if it has changed

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
@@ -572,7 +572,7 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
                 contexts[current_context].m_classification[ccc] = dec_classification.createSymbolModel(256);
                 dec_classification.initSymbolModel(contexts[current_context].m_classification[ccc]);
             }
-            last_item.Classification = (byte)dec_classification.decodeSymbol(contexts[current_context].m_classification[ccc]);
+            last_item.Classification = (short)dec_classification.decodeSymbol(contexts[current_context].m_classification[ccc]);
         }
 
         ////////////////////////////////////////

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemRaw_POINT10.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemRaw_POINT10.java
@@ -28,7 +28,7 @@ public class LASreadItemRaw_POINT10 extends LASreadItemRaw {
         result.Z = bb.getInt();
         result.Intensity = bb.getChar();
         result.Flags = bb.get();
-        result.Classification = bb.get();
+        result.Classification = (short)Byte.toUnsignedInt(bb.get());
         result.ScanAngleRank = bb.get();
         result.UserData = (short)Byte.toUnsignedInt(bb.get());
         result.PointSourceID = bb.getChar();

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemRaw_POINT14.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemRaw_POINT14.java
@@ -29,7 +29,7 @@ public class LASreadItemRaw_POINT14 extends LASreadItemRaw {
         result.Intensity = bb.getChar();
         result.ReturnFlags = bb.get();
         result.ScanFlags = bb.get();
-        result.Classification = bb.get();
+        result.Classification = (short)Byte.toUnsignedInt(bb.get());
         result.UserData = (short)Byte.toUnsignedInt(bb.get());
         result.ScanAngle = bb.getShort();
         result.PointSourceID = bb.getChar();


### PR DESCRIPTION
All 8 bits of the classification byte have the potential to be used, in both the older formats (0..5) and in the newer formats (6..10). The code had been reading this byte into a signed byte, and then casting it to a short. 
For the older formats, this would mean that if the 'Withheld' bit was set (bit index 7), this bit would be interpreted as a sign bit, and effectively be lost in the cast (I think!).
For the newer formats, where the entire byte is used for the classification value, any classifications > 127 are being incorrectly read as negative values.

I think the same issue applies in the compressed decoders, because the uncompressed/decoded classification value was being cast down to a signed byte, when it should be treated as an unsigned byte.

Looking at the original C++ copy of this code, a U8 is used for all of the decoding and reading of the classification byte. These code changes are attempting to produce the equivalent unsigned byte treatment in the java.
