### PR TITLE
Write las files

### DIFF
--- a/src/main/java/com/github/mreutegg/laszip4j/laslib/LASvlr_lasoriginal.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laslib/LASvlr_lasoriginal.java
@@ -12,6 +12,8 @@ package com.github.mreutegg.laszip4j.laslib;
 
 public class LASvlr_lasoriginal {
 
+    public long position;
+
     public long number_of_point_records;
     public long[] number_of_points_by_return = new long[15];
     public double max_x;

--- a/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriter.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriter.java
@@ -15,7 +15,7 @@ import com.github.mreutegg.laszip4j.laszip.LASquantizer;
 
 public abstract class LASwriter {
 
-    public LASquantizer quantizer;
+    public LASquantizer quantizer = new LASquantizer();
     public long npoints;
     public long p_count;
     public LASinventory inventory;

--- a/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
@@ -947,7 +947,8 @@ public class LASwriterLAS extends LASwriter {
 
             if (header.vlrs[i].reserved != 0xAABB)
             {
-                fprintf(stderr,"WARNING: wrong header->vlrs[%d].reserved: %d != 0xAABB\n", i, header.vlrs[i].reserved);
+                // commented out because las specification 1.4 says this mu st now be zero
+                // fprintf(stderr,"WARNING: wrong header->vlrs[%d].reserved: 0x%04x != 0xAABB\n", i, (int) header.vlrs[i].reserved);
             }
 
             // write variable length records variable after variable (to avoid alignment issues)

--- a/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
@@ -10,41 +10,1321 @@
  */
 package com.github.mreutegg.laszip4j.laslib;
 
+import com.github.mreutegg.laszip4j.laszip.ByteStreamOut;
+import com.github.mreutegg.laszip4j.laszip.ByteStreamOutArray;
+import com.github.mreutegg.laszip4j.laszip.ByteStreamOutFile;
+import com.github.mreutegg.laszip4j.laszip.ByteStreamOutOstream;
 import com.github.mreutegg.laszip4j.laszip.LASpoint;
+import com.github.mreutegg.laszip4j.laszip.LASwritePoint;
+import com.github.mreutegg.laszip4j.laszip.LASzip;
 
+import java.io.IOException;
 import java.io.PrintStream;
+import java.io.RandomAccessFile;
 
-// TODO: only dummy implementation
+import static com.github.mreutegg.laszip4j.clib.Cstdio.fclose;
+import static com.github.mreutegg.laszip4j.clib.Cstdio.fopenRAF;
+import static com.github.mreutegg.laszip4j.clib.Cstdio.fprintf;
+import static com.github.mreutegg.laszip4j.clib.Cstdio.sprintf;
+import static com.github.mreutegg.laszip4j.clib.Cstring.strcmp;
+import static com.github.mreutegg.laszip4j.laslib.LasDefinitions.LAS_TOOLS_VERSION;
+import static com.github.mreutegg.laszip4j.laszip.LASzip.LASZIP_COMPRESSOR_LAYERED_CHUNKED;
+import static com.github.mreutegg.laszip4j.laszip.LASzip.LASZIP_COMPRESSOR_NONE;
+import static com.github.mreutegg.laszip4j.laszip.MyDefs.U32_MAX;
+import static com.github.mreutegg.laszip4j.laszip.MyDefs.stringFromByteArray;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.lang.Double.doubleToLongBits;
+import static java.lang.Float.floatToIntBits;
+import static java.lang.Integer.toUnsignedLong;
+
 public class LASwriterLAS extends LASwriter {
+
+    private static final PrintStream stderr = System.err;
+
+    private RandomAccessFile file;
+    private ByteStreamOut stream;
+    private boolean delete_stream;
+    private LASwritePoint writer;
+    private long header_start_position;
+    private boolean writing_las_1_4;
+    private boolean writing_new_point_type;
+    // for delayed write of EVLRs
+    private long start_of_first_extended_variable_length_record;
+    private int number_of_extended_variable_length_records;     // unsigned
+    private LASevlr[] evlrs;
+
+    public LASwriterLAS() {
+        this.file = null;
+        this.stream = null;
+        delete_stream = TRUE;
+        this.writer = null;
+        this.writing_las_1_4 = FALSE;
+        this.writing_new_point_type = FALSE;
+        // for delayed write of EVLRs
+        this.start_of_first_extended_variable_length_record = 0;
+        this.number_of_extended_variable_length_records = 0;
+        this.evlrs = null;
+    }
+
     @Override
     public boolean write_point(LASpoint point) {
-        return false;
+        p_count++;
+        return writer.write(point.PointRecords);
     }
 
     @Override
     public boolean chunk() {
-        return false;
+        return writer.chunk();
     }
 
     @Override
     public boolean update_header(LASheader header, boolean use_inventory, boolean update_extra_bytes) {
-        return false;
+        int i;
+        if (header == null)
+        {
+            fprintf(stderr,"ERROR: header pointer is zero\n");
+            return FALSE;
+        }
+        if (stream == null)
+        {
+            fprintf(stderr,"ERROR: stream pointer is zero\n");
+            return FALSE;
+        }
+        if (!stream.isSeekable())
+        {
+            fprintf(stderr,"WARNING: stream not seekable. cannot update header.\n");
+            return FALSE;
+        }
+        if (use_inventory)
+        {
+            int number; // unsigned
+            stream.seek(header_start_position+107);
+            if (header.point_data_format >= 6)
+            {
+                number = 0; // legacy counters are zero for new point types
+            }
+            else if (inventory.extended_number_of_point_records > toUnsignedLong(U32_MAX))
+            {
+                if (header.version_minor >= 4)
+                {
+                    number = 0;
+                }
+                else
+                {
+                    fprintf(stderr,"WARNING: too many points in LAS %d.%d file. limit is %d.\n", header.version_major, header.version_minor, toUnsignedLong(U32_MAX));
+                    number = U32_MAX;
+                }
+            }
+            else
+            {
+                number = (int)inventory.extended_number_of_point_records;
+            }
+            if (!stream.put32bitsLE(number))
+            {
+                fprintf(stderr,"ERROR: updating inventory.number_of_point_records\n");
+                return FALSE;
+            }
+            npoints = inventory.extended_number_of_point_records;
+            for (i = 0; i < 5; i++)
+            {
+                if (header.point_data_format >= 6)
+                {
+                    number = 0; // legacy counters are zero for new point types
+                }
+                else if (inventory.extended_number_of_points_by_return[i+1] > toUnsignedLong(U32_MAX))
+                {
+                    if (header.version_minor >= 4)
+                    {
+                        number = 0;
+                    }
+                    else
+                    {
+                        number = U32_MAX;
+                    }
+                }
+                else
+                {
+                    number = (int)inventory.extended_number_of_points_by_return[i+1];
+                }
+                if (!stream.put32bitsLE(number))
+                {
+                    fprintf(stderr,"ERROR: updating inventory.number_of_points_by_return[%d]\n", i);
+                    return FALSE;
+                }
+            }
+            stream.seek(header_start_position+179);
+            double value;
+            value = quantizer.get_x(inventory.max_X);
+            if (!stream.put64bitsLE(doubleToLongBits(value)))
+            {
+                fprintf(stderr,"ERROR: updating inventory.max_X\n");
+                return FALSE;
+            }
+            value = quantizer.get_x(inventory.min_X);
+            if (!stream.put64bitsLE(doubleToLongBits(value)))
+            {
+                fprintf(stderr,"ERROR: updating inventory.min_X\n");
+                return FALSE;
+            }
+            value = quantizer.get_y(inventory.max_Y);
+            if (!stream.put64bitsLE(doubleToLongBits(value)))
+            {
+                fprintf(stderr,"ERROR: updating inventory.max_Y\n");
+                return FALSE;
+            }
+            value = quantizer.get_y(inventory.min_Y);
+            if (!stream.put64bitsLE(doubleToLongBits(value)))
+            {
+                fprintf(stderr,"ERROR: updating inventory.min_Y\n");
+                return FALSE;
+            }
+            value = quantizer.get_z(inventory.max_Z);
+            if (!stream.put64bitsLE(doubleToLongBits(value)))
+            {
+                fprintf(stderr,"ERROR: updating inventory.max_Z\n");
+                return FALSE;
+            }
+            value = quantizer.get_z(inventory.min_Z);
+            if (!stream.put64bitsLE(doubleToLongBits(value)))
+            {
+                fprintf(stderr,"ERROR: updating inventory.min_Z\n");
+                return FALSE;
+            }
+            // special handling for LAS 1.4 or higher.
+            if (header.version_minor >= 4)
+            {
+                stream.seek(header_start_position+247);
+                if (!stream.put64bitsLE(inventory.extended_number_of_point_records))
+                {
+                    fprintf(stderr,"ERROR: updating header->extended_number_of_point_records\n");
+                    return FALSE;
+                }
+                for (i = 0; i < 15; i++)
+                {
+                    if (!stream.put64bitsLE(inventory.extended_number_of_points_by_return[i+1]))
+                    {
+                        fprintf(stderr,"ERROR: updating header->extended_number_of_points_by_return[%d]\n", i);
+                        return FALSE;
+                    }
+                }
+            }
+        }
+        else
+        {
+            int number; // unsigned
+            stream.seek(header_start_position+107);
+            if (header.point_data_format >= 6)
+            {
+                number = 0; // legacy counters are zero for new point types
+            }
+            else
+            {
+                number = header.number_of_point_records;
+            }
+            if (!stream.put32bitsLE(number))
+            {
+                fprintf(stderr,"ERROR: updating header->number_of_point_records\n");
+                return FALSE;
+            }
+            npoints = header.number_of_point_records;
+            for (i = 0; i < 5; i++)
+            {
+                if (header.point_data_format >= 6)
+                {
+                    number = 0; // legacy counters are zero for new point types
+                }
+                else
+                {
+                    number = header.number_of_points_by_return[i];
+                }
+                if (!stream.put32bitsLE(number))
+                {
+                    fprintf(stderr,"ERROR: updating header->number_of_points_by_return[%d]\n", i);
+                    return FALSE;
+                }
+            }
+            stream.seek(header_start_position+179);
+            if (!stream.put64bitsLE(doubleToLongBits(header.max_x)))
+            {
+                fprintf(stderr,"ERROR: updating header->max_x\n");
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.min_x)))
+            {
+                fprintf(stderr,"ERROR: updating header->min_x\n");
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.max_y)))
+            {
+                fprintf(stderr,"ERROR: updating header->max_y\n");
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.min_y)))
+            {
+                fprintf(stderr,"ERROR: updating header->min_y\n");
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.max_z)))
+            {
+                fprintf(stderr,"ERROR: updating header->max_z\n");
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.min_z)))
+            {
+                fprintf(stderr,"ERROR: updating header->min_z\n");
+                return FALSE;
+            }
+            // special handling for LAS 1.3 or higher.
+            if (header.version_minor >= 3)
+            {
+                // nobody currently includes waveform. we set the field always to zero
+                if (header.start_of_waveform_data_packet_record != 0)
+                {
+                    fprintf(stderr,"WARNING: header->start_of_waveform_data_packet_record is %d. writing 0 instead.\n", header.start_of_waveform_data_packet_record);
+                    long start_of_waveform_data_packet_record = 0;
+                    if (!stream.put64bitsLE(start_of_waveform_data_packet_record))
+                    {
+                        fprintf(stderr,"ERROR: updating start_of_waveform_data_packet_record\n");
+                        return FALSE;
+                    }
+                }
+                else
+                {
+                    if (!stream.put64bitsLE(header.start_of_waveform_data_packet_record))
+                    {
+                        fprintf(stderr,"ERROR: updating header->start_of_waveform_data_packet_record\n");
+                        return FALSE;
+                    }
+                }
+            }
+            // special handling for LAS 1.4 or higher.
+            if (header.version_minor >= 4)
+            {
+                stream.seek(header_start_position+235);
+                if (!stream.put64bitsLE(header.start_of_first_extended_variable_length_record))
+                {
+                    fprintf(stderr,"ERROR: updating header->start_of_first_extended_variable_length_record\n");
+                    return FALSE;
+                }
+                if (!stream.put32bitsLE(header.number_of_extended_variable_length_records))
+                {
+                    fprintf(stderr,"ERROR: updating header->number_of_extended_variable_length_records\n");
+                    return FALSE;
+                }
+                long value;
+                if (header.number_of_point_records != 0)
+                    value = header.number_of_point_records;
+                else
+                    value = header.extended_number_of_point_records;
+                if (!stream.put64bitsLE(value))
+                {
+                    fprintf(stderr,"ERROR: updating header->extended_number_of_point_records\n");
+                    return FALSE;
+                }
+                for (i = 0; i < 15; i++)
+                {
+                    if ((i < 5) && header.number_of_points_by_return[i] != 0)
+                        value = header.number_of_points_by_return[i];
+                    else
+                        value = header.extended_number_of_points_by_return[i];
+                    if (!stream.put64bitsLE(value))
+                    {
+                        fprintf(stderr,"ERROR: updating header->extended_number_of_points_by_return[%d]\n", i);
+                        return FALSE;
+                    }
+                }
+            }
+        }
+        stream.seekEnd();
+        if (update_extra_bytes)
+        {
+            if (header == null)
+            {
+                fprintf(stderr,"ERROR: header pointer is zero\n");
+                return FALSE;
+            }
+            if (header.number_attributes != 0)
+            {
+                long start = header_start_position + header.header_size;
+                for (i = 0; i < header.number_of_variable_length_records; i++)
+                {
+                    start += 54;
+                    if ((header.vlrs[i].record_id == 4) && (strcmp(header.vlrs[i].user_id, "LASF_Spec") == 0))
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        start += header.vlrs[i].record_length_after_header;
+                    }
+                }
+                if (i == header.number_of_variable_length_records)
+                {
+                    fprintf(stderr,"WARNING: could not find extra bytes VLR for update\n");
+                }
+                else
+                {
+                    stream.seek(start);
+                    if (!stream.putBytes(header.vlrs[i].data, header.vlrs[i].record_length_after_header))
+                    {
+                        fprintf(stderr,"ERROR: writing %d bytes of data from header->vlrs[%d].data\n", header.vlrs[i].record_length_after_header, i);
+                        return FALSE;
+                    }
+                }
+            }
+            stream.seekEnd();
+        }
+        return TRUE;
     }
 
     @Override
     public long close(boolean update_npoints) {
-        return 0;
+        long bytes = 0;
+
+        if (p_count != npoints)
+        {
+            if (npoints != 0 || !update_npoints)
+            {
+                fprintf(stderr,"WARNING: written %lld points but expected %d points\n", p_count, npoints);
+            }
+        }
+
+        if (writer != null)
+        {
+            writer.done();
+            writer = null;
+        }
+
+        if (writing_las_1_4 && number_of_extended_variable_length_records != 0)
+        {
+            long real_start_of_first_extended_variable_length_record = stream.tell();
+
+            // write extended variable length records variable after variable (to avoid alignment issues)
+
+            for (int i = 0; i < number_of_extended_variable_length_records; i++)
+            {
+                // check variable length records contents
+
+                if (evlrs[i].reserved != 0xAABB)
+                {
+                    fprintf(stderr,"WARNING: wrong evlrs[%d].reserved: %d != 0xAABB\n", i, evlrs[i].reserved);
+                }
+
+                // write variable length records variable after variable (to avoid alignment issues)
+
+                if (!stream.put16bitsLE(evlrs[i].reserved))
+                {
+                    fprintf(stderr,"ERROR: writing evlrs[%d].reserved\n", i);
+                    return 0;
+                }
+                if (!stream.putBytes(evlrs[i].user_id, 16))
+                {
+                    fprintf(stderr,"ERROR: writing evlrs[%d].user_id\n", i);
+                    return 0;
+                }
+                if (!stream.put16bitsLE(evlrs[i].record_id))
+                {
+                    fprintf(stderr,"ERROR: writing evlrs[%d].record_id\n", i);
+                    return 0;
+                }
+                if (!stream.put64bitsLE(evlrs[i].record_length_after_header))
+                {
+                    fprintf(stderr,"ERROR: writing evlrs[%d].record_length_after_header\n", i);
+                    return 0;
+                }
+                if (!stream.putBytes(evlrs[i].description, 32))
+                {
+                    fprintf(stderr,"ERROR: writing evlrs[%d].description\n", i);
+                    return 0;
+                }
+
+                // write the data following the header of the variable length record
+
+                if (evlrs[i].record_length_after_header != 0)
+                {
+                    if (evlrs[i].data != null)
+                    {
+                        if (!stream.putBytes(evlrs[i].data, (int) evlrs[i].record_length_after_header))
+                        {
+                            fprintf(stderr,"ERROR: writing %d bytes of data from evlrs[%d].data\n", evlrs[i].record_length_after_header, i);
+                            return 0;
+                        }
+                    }
+                    else
+                    {
+                        fprintf(stderr,"ERROR: there should be %d bytes of data in evlrs[%d].data\n", evlrs[i].record_length_after_header, i);
+                        return 0;
+                    }
+                }
+            }
+
+            if (real_start_of_first_extended_variable_length_record != start_of_first_extended_variable_length_record)
+            {
+                stream.seek(header_start_position+235);
+                stream.put64bitsLE(real_start_of_first_extended_variable_length_record);
+                stream.seekEnd();
+            }
+        }
+
+        if (stream != null)
+        {
+            if (update_npoints && p_count != npoints)
+            {
+                if (!stream.isSeekable())
+                {
+                    fprintf(stderr, "WARNING: stream not seekable. cannot update header from %d to %d points.\n", npoints, p_count);
+                }
+                else
+                {
+                    int number; // unsigned
+                    if (writing_new_point_type)
+                    {
+                        number = 0;
+                    }
+                    else if (p_count > toUnsignedLong(U32_MAX))
+                    {
+                        if (writing_las_1_4)
+                        {
+                            number = 0;
+                        }
+                        else
+                        {
+                            number = U32_MAX;
+                        }
+                    }
+                    else
+                    {
+                        number = (int)p_count;
+                    }
+                    stream.seek(header_start_position+107);
+                    stream.put32bitsLE(number);
+                    if (writing_las_1_4)
+                    {
+                        stream.seek(header_start_position+235+12);
+                        stream.put64bitsLE(p_count);
+                    }
+                    stream.seekEnd();
+                }
+            }
+            bytes = stream.tell() - header_start_position;
+            if (delete_stream)
+            {
+                try {
+                    stream.close();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            stream = null;
+        }
+
+        if (file != null)
+        {
+            fclose(file);
+            file = null;
+        }
+
+        npoints = p_count;
+        p_count = 0;
+
+        return bytes;
     }
 
-    public boolean open(LASheader header, char c, int i, int chunk_size) {
-        return false;
+    public boolean open(LASheader header, char compressor, int requested_version, int chunk_size) {
+        ByteStreamOut out = new ByteStreamOutArray();
+        return open(out, header, compressor, requested_version, chunk_size);
     }
 
-    public boolean open(String file_name, LASheader header, char c, int i, int chunk_size, int io_obuffer_size) {
-        return false;
+    public boolean open(String file_name, LASheader header, char compressor, int requested_version, int chunk_size, int io_buffer_size) {
+        if (file_name == null)
+        {
+            fprintf(stderr,"ERROR: file name is null\n");
+            return FALSE;
+        }
+
+        file = fopenRAF(file_name.toCharArray(), "wb");
+
+        if (file == null)
+        {
+            fprintf(stderr, "ERROR: cannot open file '%s' for write\n", file_name);
+            return FALSE;
+        }
+
+        return open(file, header, compressor, requested_version, chunk_size);
     }
 
-    public boolean open(PrintStream stdout, LASheader header, char c, int i, int chunk_size) {
-        return false;
+    public boolean open(RandomAccessFile file, LASheader header, char compressor, int requested_version, int chunk_size) {
+        ByteStreamOut out = new ByteStreamOutFile(file);
+        return open(out, header, compressor, requested_version, chunk_size);
+    }
+
+    public boolean open(PrintStream stdout, LASheader header, char compressor, int requested_version, int chunk_size) {
+        ByteStreamOut out = new ByteStreamOutOstream(stdout);
+        return open(out, header, compressor, requested_version, chunk_size);
+    }
+
+    public boolean open(ByteStreamOut stream, LASheader header, char compressor, int requested_version, int chunk_size)
+    {
+        int i, j; // unsigned
+
+        if (stream == null)
+        {
+            fprintf(stderr,"ERROR: ByteStreamOut pointer is zero\n");
+            return FALSE;
+        }
+        this.stream = stream;
+
+        if (header == null)
+        {
+            fprintf(stderr,"ERROR: LASheader pointer is zero\n");
+            return FALSE;
+        }
+
+        // check header contents
+
+        if (!header.check()) return FALSE;
+
+        // copy scale_and_offset
+        quantizer.x_scale_factor = header.x_scale_factor;
+        quantizer.y_scale_factor = header.y_scale_factor;
+        quantizer.z_scale_factor = header.z_scale_factor;
+        quantizer.x_offset = header.x_offset;
+        quantizer.y_offset = header.y_offset;
+        quantizer.z_offset = header.z_offset;
+
+        // check if the requested point type is supported
+
+        LASpoint point = new LASpoint();
+        byte[] point_data_format = new byte[1]; // unsigned
+        char[] point_data_record_length = new char[1]; // unsigned
+        boolean point_is_standard = TRUE;
+
+        if (header.laszip != null)
+        {
+            if (!point.init(quantizer, header.laszip.num_items, header.laszip.items, header)) return FALSE;
+            point_is_standard = header.laszip.is_standard(point_data_format, point_data_record_length);
+        }
+        else
+        {
+            if (!point.init(quantizer, header.point_data_format, header.point_data_record_length, header)) return FALSE;
+            point_data_format[0] = header.point_data_format;
+            point_data_record_length[0] = header.point_data_record_length;
+        }
+
+        // fail if we don't use the layered compressor for the new LAS 1.4 point types
+
+        if (compressor != 0 && (point_data_format[0] > 5) && (compressor != LASZIP_COMPRESSOR_LAYERED_CHUNKED))
+        {
+            fprintf(stderr,"ERROR: point type %d requires using \"native LAS 1.4 extension\" of LASzip\n", point_data_format[0]);
+            return FALSE;
+        }
+
+        // do we need a LASzip VLR (because we compress or use non-standard points?)
+
+        LASzip laszip = null;
+        int laszip_vlr_data_size = 0; // unsigned
+        if (compressor != 0 || point_is_standard == FALSE)
+        {
+            laszip = new LASzip();
+            laszip.setup(point.num_items, point.items, compressor);
+            if (chunk_size > -1) laszip.set_chunk_size(chunk_size);
+            if (compressor == LASZIP_COMPRESSOR_NONE) laszip.request_version((char) 0);
+            else if (chunk_size == 0 && (point_data_format[0] <= 5)) { fprintf(stderr,"ERROR: adaptive chunking is depricated for point type %d.\n       only available for new LAS 1.4 point types 6 or higher.\n", point_data_format[0]); return FALSE; }
+            else if (requested_version != 0) laszip.request_version((char) requested_version);
+            else laszip.request_version((char) 2);
+            laszip_vlr_data_size = 34 + 6*laszip.num_items;
+        }
+
+        // create and setup the point writer
+
+        writer = new LASwritePoint();
+        if (laszip != null)
+        {
+            if (!writer.setup(laszip.num_items, laszip.items, laszip))
+            {
+                fprintf(stderr,"ERROR: point type %d of size %d not supported (with LASzip)\n", header.point_data_format, header.point_data_record_length);
+                return FALSE;
+            }
+        }
+        else
+        {
+            if (!writer.setup(point.num_items, point.items))
+            {
+                fprintf(stderr,"ERROR: point type %d of size %d not supported\n", header.point_data_format, header.point_data_record_length);
+                return FALSE;
+            }
+        }
+
+        // save the position where we start writing the header
+
+        header_start_position = stream.tell();
+
+        // write header variable after variable (to avoid alignment issues)
+
+        if (!stream.putBytes(header.file_signature, 4))
+        {
+            fprintf(stderr,"ERROR: writing header->file_signature\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.file_source_ID))
+        {
+            fprintf(stderr,"ERROR: writing header->file_source_ID\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.global_encoding))
+        {
+            fprintf(stderr,"ERROR: writing header->global_encoding\n");
+            return FALSE;
+        }
+        if (!stream.put32bitsLE(header.project_ID_GUID_data_1))
+        {
+            fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_1\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.project_ID_GUID_data_2))
+        {
+            fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_2\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.project_ID_GUID_data_3))
+        {
+            fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_3\n");
+            return FALSE;
+        }
+        if (!stream.putBytes(header.project_ID_GUID_data_4, 8))
+        {
+            fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_4\n");
+            return FALSE;
+        }
+        // check version major
+        byte version_major = header.version_major; // unsigned
+        if (header.version_major != 1)
+        {
+            fprintf(stderr,"WARNING: header->version_major is %d. writing 1 instead.\n", header.version_major);
+            version_major = 1;
+        }
+        if (!stream.putByte(version_major))
+        {
+            fprintf(stderr,"ERROR: writing header->version_major\n");
+            return FALSE;
+        }
+        // check version minor
+        byte version_minor = header.version_minor; // unsigned
+        if (version_minor > 4)
+        {
+            fprintf(stderr,"WARNING: header->version_minor is %d. writing 4 instead.\n", version_minor);
+            version_minor = 4;
+        }
+        if (!stream.putByte(version_minor))
+        {
+            fprintf(stderr,"ERROR: writing header->version_minor\n");
+            return FALSE;
+        }
+        if (!stream.putBytes(header.system_identifier, 32))
+        {
+            fprintf(stderr,"ERROR: writing header->system_identifier\n");
+            return FALSE;
+        }
+        if (!stream.putBytes(header.generating_software, 32))
+        {
+            fprintf(stderr,"ERROR: writing header->generating_software\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.file_creation_day))
+        {
+            fprintf(stderr,"ERROR: writing header->file_creation_day\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.file_creation_year))
+        {
+            fprintf(stderr,"ERROR: writing header->file_creation_year\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.header_size))
+        {
+            fprintf(stderr,"ERROR: writing header->header_size\n");
+            return FALSE;
+        }
+        int offset_to_point_data = header.offset_to_point_data; // unsigned
+        if (laszip != null) offset_to_point_data += (54 + laszip_vlr_data_size);
+        if (header.vlr_lastiling != null) offset_to_point_data += (54 + 28);
+        if (header.vlr_lasoriginal != null) offset_to_point_data += (54 + 176);
+        if (!stream.put32bitsLE(offset_to_point_data))
+        {
+            fprintf(stderr,"ERROR: writing header->offset_to_point_data\n");
+            return FALSE;
+        }
+        int number_of_variable_length_records = header.number_of_variable_length_records; // unsigned
+        if (laszip != null) number_of_variable_length_records++;
+        if (header.vlr_lastiling != null) number_of_variable_length_records++;
+        if (header.vlr_lasoriginal != null) number_of_variable_length_records++;
+        if (!stream.put32bitsLE(number_of_variable_length_records))
+        {
+            fprintf(stderr,"ERROR: writing header->number_of_variable_length_records\n");
+            return FALSE;
+        }
+        if (compressor != 0) point_data_format[0] |= 128;
+        if (!stream.putByte(point_data_format[0]))
+        {
+            fprintf(stderr,"ERROR: writing header->point_data_format\n");
+            return FALSE;
+        }
+        if (!stream.put16bitsLE(header.point_data_record_length))
+        {
+            fprintf(stderr,"ERROR: writing header->point_data_record_length\n");
+            return FALSE;
+        }
+        if (!stream.put32bitsLE(header.number_of_point_records))
+        {
+            fprintf(stderr,"ERROR: writing header->number_of_point_records\n");
+            return FALSE;
+        }
+        for (i = 0; i < 5; i++)
+        {
+            if (!stream.put32bitsLE(header.number_of_points_by_return[i]))
+            {
+                fprintf(stderr,"ERROR: writing header->number_of_points_by_return[%d]\n", i);
+                return FALSE;
+            }
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.x_scale_factor)))
+        {
+            fprintf(stderr,"ERROR: writing header->x_scale_factor\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.y_scale_factor)))
+        {
+            fprintf(stderr,"ERROR: writing header->y_scale_factor\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.z_scale_factor)))
+        {
+            fprintf(stderr,"ERROR: writing header->z_scale_factor\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.x_offset)))
+        {
+            fprintf(stderr,"ERROR: writing header->x_offset\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.y_offset)))
+        {
+            fprintf(stderr,"ERROR: writing header->y_offset\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.z_offset)))
+        {
+            fprintf(stderr,"ERROR: writing header->z_offset\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.max_x)))
+        {
+            fprintf(stderr,"ERROR: writing header->max_x\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.min_x)))
+        {
+            fprintf(stderr,"ERROR: writing header->min_x\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.max_y)))
+        {
+            fprintf(stderr,"ERROR: writing header->max_y\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.min_y)))
+        {
+            fprintf(stderr,"ERROR: writing header->min_y\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.max_z)))
+        {
+            fprintf(stderr,"ERROR: writing header->max_z\n");
+            return FALSE;
+        }
+        if (!stream.put64bitsLE(doubleToLongBits(header.min_z)))
+        {
+            fprintf(stderr,"ERROR: writing header->min_z\n");
+            return FALSE;
+        }
+
+        // special handling for LAS 1.3 or higher.
+        if (version_minor >= 3)
+        {
+            long start_of_waveform_data_packet_record = header.start_of_waveform_data_packet_record; // unsigned
+            if (start_of_waveform_data_packet_record != 0)
+            {
+                fprintf(stderr,"WARNING: header->start_of_waveform_data_packet_record is %d. writing 0 instead.\n", start_of_waveform_data_packet_record);
+                start_of_waveform_data_packet_record = 0;
+            }
+            if (!stream.put64bitsLE(start_of_waveform_data_packet_record))
+            {
+                fprintf(stderr,"ERROR: writing start_of_waveform_data_packet_record\n");
+                return FALSE;
+            }
+        }
+
+        // special handling for LAS 1.4 or higher.
+        if (version_minor >= 4)
+        {
+            writing_las_1_4 = TRUE;
+            if (header.point_data_format >= 6)
+            {
+                writing_new_point_type = TRUE;
+            }
+            else
+            {
+                writing_new_point_type = FALSE;
+            }
+            start_of_first_extended_variable_length_record = header.start_of_first_extended_variable_length_record;
+            if (!stream.put64bitsLE(start_of_first_extended_variable_length_record))
+            {
+                fprintf(stderr,"ERROR: writing header->start_of_first_extended_variable_length_record\n");
+                return FALSE;
+            }
+            number_of_extended_variable_length_records = header.number_of_extended_variable_length_records;
+            if (!stream.put32bitsLE(number_of_extended_variable_length_records))
+            {
+                fprintf(stderr,"ERROR: writing header->number_of_extended_variable_length_records\n");
+                return FALSE;
+            }
+            evlrs = header.evlrs;
+            long extended_number_of_point_records; // unsigned
+            if (header.number_of_point_records != 0)
+                extended_number_of_point_records = header.number_of_point_records;
+            else
+                extended_number_of_point_records = header.extended_number_of_point_records;
+            if (!stream.put64bitsLE(extended_number_of_point_records))
+            {
+                fprintf(stderr,"ERROR: writing header->extended_number_of_point_records\n");
+                return FALSE;
+            }
+            long extended_number_of_points_by_return; // unsigned
+            for (i = 0; i < 15; i++)
+            {
+                if ((i < 5) && header.number_of_points_by_return[i] != 0)
+                    extended_number_of_points_by_return = header.number_of_points_by_return[i];
+                else
+                    extended_number_of_points_by_return = header.extended_number_of_points_by_return[i];
+                if (!stream.put64bitsLE(extended_number_of_points_by_return))
+                {
+                    fprintf(stderr,"ERROR: writing header->extended_number_of_points_by_return[%d]\n", i);
+                    return FALSE;
+                }
+            }
+        }
+        else
+        {
+            writing_las_1_4 = FALSE;
+            writing_new_point_type = FALSE;
+        }
+
+        // write any number of user-defined bytes that might have been added into the header
+
+        if (header.user_data_in_header_size != 0)
+        {
+            if (header.user_data_in_header != null)
+            {
+                if (!stream.putBytes(header.user_data_in_header, header.user_data_in_header_size))
+                {
+                    fprintf(stderr,"ERROR: writing %d bytes of data from header->user_data_in_header\n", header.user_data_in_header_size);
+                    return FALSE;
+                }
+            }
+            else
+            {
+                fprintf(stderr,"ERROR: there should be %d bytes of data in header->user_data_in_header\n", header.user_data_in_header_size);
+                return FALSE;
+            }
+        }
+
+        // write variable length records variable after variable (to avoid alignment issues)
+
+        for (i = 0; i < header.number_of_variable_length_records; i++)
+        {
+            // check variable length records contents
+
+            if (header.vlrs[i].reserved != 0xAABB)
+            {
+                fprintf(stderr,"WARNING: wrong header->vlrs[%d].reserved: %d != 0xAABB\n", i, header.vlrs[i].reserved);
+            }
+
+            // write variable length records variable after variable (to avoid alignment issues)
+
+            if (!stream.put16bitsLE(header.vlrs[i].reserved))
+            {
+                fprintf(stderr,"ERROR: writing header->vlrs[%d].reserved\n", i);
+                return FALSE;
+            }
+            if (!stream.putBytes(header.vlrs[i].user_id, 16))
+            {
+                fprintf(stderr,"ERROR: writing header->vlrs[%d].user_id\n", i);
+                return FALSE;
+            }
+            if (!stream.put16bitsLE(header.vlrs[i].record_id))
+            {
+                fprintf(stderr,"ERROR: writing header->vlrs[%d].record_id\n", i);
+                return FALSE;
+            }
+            if (!stream.put16bitsLE(header.vlrs[i].record_length_after_header))
+            {
+                fprintf(stderr,"ERROR: writing header->vlrs[%d].record_length_after_header\n", i);
+                return FALSE;
+            }
+            if (!stream.putBytes(header.vlrs[i].description, 32))
+            {
+                fprintf(stderr,"ERROR: writing header->vlrs[%d].description\n", i);
+                return FALSE;
+            }
+
+            // write the data following the header of the variable length record
+
+            if (header.vlrs[i].record_length_after_header != 0)
+            {
+                if (header.vlrs[i].data != null)
+                {
+                    if (!stream.putBytes(header.vlrs[i].data, header.vlrs[i].record_length_after_header))
+                    {
+                        fprintf(stderr,"ERROR: writing %d bytes of data from header->vlrs[%d].data\n", header.vlrs[i].record_length_after_header, i);
+                        return FALSE;
+                    }
+                }
+                else
+                {
+                    fprintf(stderr,"ERROR: there should be %d bytes of data in header->vlrs[%d].data\n", header.vlrs[i].record_length_after_header, i);
+                    return FALSE;
+                }
+            }
+        }
+
+        // write laszip VLR with compression parameters
+
+        if (laszip != null)
+        {
+            // write variable length records variable after variable (to avoid alignment issues)
+
+            char reserved = 0xAABB; // unsigned
+            if (!stream.put16bitsLE(reserved))
+            {
+                fprintf(stderr,"ERROR: writing reserved %d\n", (int)reserved);
+                return FALSE;
+            }
+            byte[] user_id = new byte[16];
+            sprintf(user_id, "laszip encoded");
+            if (!stream.putBytes(user_id, 16))
+            {
+                fprintf(stderr,"ERROR: writing user_id %s\n", stringFromByteArray(user_id));
+                return FALSE;
+            }
+            char record_id = 22204; // unsigned
+            if (!stream.put16bitsLE(record_id))
+            {
+                fprintf(stderr,"ERROR: writing record_id %d\n", (int)record_id);
+                return FALSE;
+            }
+            char record_length_after_header = (char) laszip_vlr_data_size; // unsigned
+            if (!stream.put16bitsLE(record_length_after_header))
+            {
+                fprintf(stderr,"ERROR: writing record_length_after_header %d\n", (int)record_length_after_header);
+                return FALSE;
+            }
+            byte[] description = new byte[32];
+            sprintf(description, "by laszip of LAStools (%d)", LAS_TOOLS_VERSION);
+            if (!stream.putBytes(description, 32))
+            {
+                fprintf(stderr,"ERROR: writing description %s\n", stringFromByteArray(description));
+                return FALSE;
+            }
+            // write the data following the header of the variable length record
+            //     U16  compressor                2 bytes
+            //     U32  coder                     2 bytes
+            //     U8   version_major             1 byte
+            //     U8   version_minor             1 byte
+            //     U16  version_revision          2 bytes
+            //     U32  options                   4 bytes
+            //     I32  chunk_size                4 bytes
+            //     I64  number_of_special_evlrs   8 bytes
+            //     I64  offset_to_special_evlrs   8 bytes
+            //     U16  num_items                 2 bytes
+            //        U16 type                2 bytes * num_items
+            //        U16 size                2 bytes * num_items
+            //        U16 version             2 bytes * num_items
+            // which totals 34+6*num_items
+
+            if (!stream.put16bitsLE(laszip.compressor))
+            {
+                fprintf(stderr,"ERROR: writing compressor %d\n", (int)compressor);
+                return FALSE;
+            }
+            if (!stream.put16bitsLE(laszip.coder))
+            {
+                fprintf(stderr,"ERROR: writing coder %d\n", (int)laszip.coder);
+                return FALSE;
+            }
+            if (!stream.putByte(laszip.version_major))
+            {
+                fprintf(stderr,"ERROR: writing version_major %d\n", laszip.version_major);
+                return FALSE;
+            }
+            if (!stream.putByte(laszip.version_minor))
+            {
+                fprintf(stderr,"ERROR: writing version_minor %d\n", laszip.version_minor);
+                return FALSE;
+            }
+            if (!stream.put16bitsLE(laszip.version_revision))
+            {
+                fprintf(stderr,"ERROR: writing version_revision %d\n", laszip.version_revision);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(laszip.options))
+            {
+                fprintf(stderr,"ERROR: writing options %d\n", laszip.options);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(laszip.chunk_size))
+            {
+                fprintf(stderr,"ERROR: writing chunk_size %d\n", laszip.chunk_size);
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(laszip.number_of_special_evlrs))
+            {
+                fprintf(stderr,"ERROR: writing number_of_special_evlrs %d\n", (int)laszip.number_of_special_evlrs);
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(laszip.offset_to_special_evlrs))
+            {
+                fprintf(stderr,"ERROR: writing offset_to_special_evlrs %d\n", laszip.offset_to_special_evlrs);
+                return FALSE;
+            }
+            if (!stream.put16bitsLE(laszip.num_items))
+            {
+                fprintf(stderr,"ERROR: writing num_items %d\n", laszip.num_items);
+                return FALSE;
+            }
+            for (i = 0; i < laszip.num_items; i++)
+            {
+                if (!stream.put16bitsLE((char) laszip.items[i].type.ordinal()))
+                {
+                    fprintf(stderr,"ERROR: writing type %d of item %d\n", laszip.items[i].type.ordinal(), i);
+                    return FALSE;
+                }
+                if (!stream.put16bitsLE(laszip.items[i].size))
+                {
+                    fprintf(stderr,"ERROR: writing size %d of item %d\n", laszip.items[i].size, i);
+                    return FALSE;
+                }
+                if (!stream.put16bitsLE(laszip.items[i].version))
+                {
+                    fprintf(stderr,"ERROR: writing version %d of item %d\n", laszip.items[i].version, i);
+                    return FALSE;
+                }
+            }
+
+            laszip = null;
+        }
+
+        // write lastiling VLR with the tile parameters
+
+        if (header.vlr_lastiling != null)
+        {
+            // write variable length records variable after variable (to avoid alignment issues)
+
+            char reserved = 0xAABB; // unsigned
+            if (!stream.put16bitsLE(reserved))
+            {
+                fprintf(stderr,"ERROR: writing reserved %d\n", (int)reserved);
+                return FALSE;
+            }
+            byte[] user_id = new byte[16];
+            sprintf(user_id, "LAStools");
+            if (!stream.putBytes(user_id, 16))
+            {
+                fprintf(stderr,"ERROR: writing user_id %s\n", stringFromByteArray(user_id));
+                return FALSE;
+            }
+            char record_id = 10; // unsigned
+            if (!stream.put16bitsLE(record_id))
+            {
+                fprintf(stderr,"ERROR: writing record_id %d\n", (int)record_id);
+                return FALSE;
+            }
+            char record_length_after_header = 28; // unsigned
+            if (!stream.put16bitsLE(record_length_after_header))
+            {
+                fprintf(stderr,"ERROR: writing record_length_after_header %d\n", (int)record_length_after_header);
+                return FALSE;
+            }
+            byte[] description = new byte[32];
+            sprintf(description, "tile %s buffer %s", (header.vlr_lastiling.buffer != 0 ? "with" : "without"), (header.vlr_lastiling.reversible != 0 ? ", reversible" : ""));
+            if (!stream.putBytes(description, 32))
+            {
+                fprintf(stderr,"ERROR: writing description %s\n", stringFromByteArray(description));
+                return FALSE;
+            }
+
+            // write the payload of this VLR which contains 28 bytes
+            //   U32  level                                          4 bytes
+            //   U32  level_index                                    4 bytes
+            //   U32  implicit_levels + buffer bit + reversible bit  4 bytes
+            //   F32  min_x                                          4 bytes
+            //   F32  max_x                                          4 bytes
+            //   F32  min_y                                          4 bytes
+            //   F32  max_y                                          4 bytes
+
+            if (!stream.put32bitsLE(header.vlr_lastiling.level))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lastiling->level %u\n", header.vlr_lastiling.level);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(header.vlr_lastiling.level_index))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lastiling->level_index %u\n", header.vlr_lastiling.level_index);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(header.vlr_lastiling.implicit_levels))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lastiling->implicit_levels %u\n", header.vlr_lastiling.implicit_levels);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(floatToIntBits(header.vlr_lastiling.min_x)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lastiling->min_x %g\n", header.vlr_lastiling.min_x);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(floatToIntBits(header.vlr_lastiling.max_x)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lastiling->max_x %g\n", header.vlr_lastiling.max_x);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(floatToIntBits(header.vlr_lastiling.min_y)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lastiling->min_y %g\n", header.vlr_lastiling.min_y);
+                return FALSE;
+            }
+            if (!stream.put32bitsLE(floatToIntBits(header.vlr_lastiling.max_y)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lastiling->max_y %g\n", header.vlr_lastiling.max_y);
+                return FALSE;
+            }
+        }
+
+        // write lasoriginal VLR with the original (unbuffered) counts and bounding box extent
+
+        if (header.vlr_lasoriginal != null)
+        {
+            // write variable length records variable after variable (to avoid alignment issues)
+
+            char reserved = 0xAABB; // unsigned
+            if (!stream.put16bitsLE(reserved))
+            {
+                fprintf(stderr,"ERROR: writing reserved %d\n", (int)reserved);
+                return FALSE;
+            }
+            byte[] user_id = new byte[16];
+            sprintf(user_id, "LAStools");
+            if (!stream.putBytes(user_id, 16))
+            {
+                fprintf(stderr,"ERROR: writing user_id %s\n", stringFromByteArray(user_id));
+                return FALSE;
+            }
+            char record_id = 20; // unsigned
+            if (!stream.put16bitsLE(record_id))
+            {
+                fprintf(stderr,"ERROR: writing record_id %d\n", (int)record_id);
+                return FALSE;
+            }
+            char record_length_after_header = 176; // unsigned
+            if (!stream.put16bitsLE(record_length_after_header))
+            {
+                fprintf(stderr,"ERROR: writing record_length_after_header %d\n", (int)record_length_after_header);
+                return FALSE;
+            }
+            byte[] description = new byte[32];
+            sprintf(description, "counters and bbox of original");
+            if (!stream.putBytes(description, 32))
+            {
+                fprintf(stderr,"ERROR: writing description %s\n", stringFromByteArray(description));
+                return FALSE;
+            }
+
+            // save the position in the stream at which the payload of this VLR was written
+
+            header.vlr_lasoriginal.position = stream.tell();
+
+            // write the payload of this VLR which contains 176 bytes
+
+            if (!stream.put64bitsLE(header.vlr_lasoriginal.number_of_point_records))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->number_of_point_records %d\n", header.vlr_lasoriginal.number_of_point_records);
+                return FALSE;
+            }
+            for (j = 0; j < 15; j++)
+            {
+                if (!stream.put64bitsLE(header.vlr_lasoriginal.number_of_points_by_return[j]))
+                {
+                    fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->number_of_points_by_return[%u] %d\n", j, header.vlr_lasoriginal.number_of_points_by_return[j]);
+                    return FALSE;
+                }
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.vlr_lasoriginal.min_x)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->min_x %g\n", header.vlr_lasoriginal.min_x);
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.vlr_lasoriginal.max_x)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->max_x %g\n", header.vlr_lasoriginal.max_x);
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.vlr_lasoriginal.min_y)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->min_y %g\n", header.vlr_lasoriginal.min_y);
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.vlr_lasoriginal.max_y)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->max_y %g\n", header.vlr_lasoriginal.max_y);
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.vlr_lasoriginal.min_z)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->min_z %g\n", header.vlr_lasoriginal.min_z);
+                return FALSE;
+            }
+            if (!stream.put64bitsLE(doubleToLongBits(header.vlr_lasoriginal.max_z)))
+            {
+                fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->max_z %g\n", header.vlr_lasoriginal.max_z);
+                return FALSE;
+            }
+        }
+
+        // write any number of user-defined bytes that might have been added after the header
+
+        if (header.user_data_after_header_size != 0)
+        {
+            if (header.user_data_after_header != null)
+            {
+                if (!stream.putBytes(header.user_data_after_header, header.user_data_after_header_size))
+                {
+                    fprintf(stderr,"ERROR: writing %d bytes of data from header->user_data_after_header\n", header.user_data_after_header_size);
+                    return FALSE;
+                }
+            }
+            else
+            {
+                fprintf(stderr,"ERROR: there should be %d bytes of data in header->user_data_after_header\n", header.user_data_after_header_size);
+                return FALSE;
+            }
+        }
+
+        // initialize the point writer
+
+        if (!writer.init(stream)) return FALSE;
+
+        npoints = (header.number_of_point_records != 0 ? header.number_of_point_records : header.extended_number_of_point_records);
+        p_count = 0;
+
+        return TRUE;
     }
 }

--- a/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
@@ -543,7 +543,7 @@ public class LASwriterLAS extends LASwriter {
             return FALSE;
         }
 
-        file = fopenRAF(file_name.toCharArray(), "wb");
+        file = fopenRAF(file_name.toCharArray(), "rwb");
 
         if (file == null)
         {

--- a/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laslib/LASwriterLAS.java
@@ -408,7 +408,8 @@ public class LASwriterLAS extends LASwriter {
 
                 if (evlrs[i].reserved != 0xAABB)
                 {
-                    fprintf(stderr,"WARNING: wrong evlrs[%d].reserved: %d != 0xAABB\n", i, evlrs[i].reserved);
+                    // commented out because las specification 1.4 says this must now be zero
+                    // fprintf(stderr,"WARNING: wrong evlrs[%d].reserved: 0x%04x != 0xAABB\n", i, (int) evlrs[i].reserved);
                 }
 
                 // write variable length records variable after variable (to avoid alignment issues)
@@ -947,7 +948,7 @@ public class LASwriterLAS extends LASwriter {
 
             if (header.vlrs[i].reserved != 0xAABB)
             {
-                // commented out because las specification 1.4 says this mu st now be zero
+                // commented out because las specification 1.4 says this must now be zero
                 // fprintf(stderr,"WARNING: wrong header->vlrs[%d].reserved: 0x%04x != 0xAABB\n", i, (int) header.vlrs[i].reserved);
             }
 

--- a/src/main/java/com/github/mreutegg/laszip4j/lastools/Laszip.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/lastools/Laszip.java
@@ -609,7 +609,7 @@ public class Laszip {
                                     if ( null != laswriter)
                                         laswriter.write_point(lasreader.point);
                                     
-                                    System.out.println(lasreader.point.get_x()+" "+lasreader.point.get_y()+" ="+lasreader.point.get_z()+" "+lasreader.point.getIntensity()+" "+lasreader.point.getClassification());
+                                    // System.out.println(lasreader.point.get_x()+" "+lasreader.point.get_y()+" ="+lasreader.point.get_z()+" "+lasreader.point.getIntensity()+" "+lasreader.point.getClassification());
                                 }
                             }
                             if ( null != laswriter)

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOut.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOut.java
@@ -52,8 +52,10 @@ public abstract class ByteStreamOut implements Closeable {
     public abstract boolean putBytes(byte[] bytes, int u_num_bytes);
     /* write 16 bit low-endian field                             */
     public abstract boolean put16bitsLE(char bytes);
+    /* write 16 bit low-endian field                             */
+    public abstract boolean put16bitsLE(short bytes);
     /* write 32 bit low-endian field                             */
-    abstract boolean put32bitsLE(int bytes);
+    public abstract boolean put32bitsLE(int bytes);
     /* write 64 bit low-endian field                             */
     public abstract boolean put64bitsLE(long bytes);
     /* write 16 bit big-endian field                             */

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutArray.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutArray.java
@@ -87,6 +87,14 @@ public class ByteStreamOutArray extends ByteStreamOut {
     }
 
     @Override
+    public boolean put16bitsLE(short bytes) {
+        ensureCapacity(2);
+        data.putShort(bytes);
+        updateSize();
+        return true;
+    }
+
+    @Override
     public boolean put32bitsLE(int bytes) {
         ensureCapacity(4);
         data.putInt(bytes);

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutDataOutput.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutDataOutput.java
@@ -58,8 +58,13 @@ abstract class ByteStreamOutDataOutput extends ByteStreamOut {
         return putBytes(buffer.array(), 2);
     }
 
+    public boolean put16bitsLE(short bytes) {
+        bufferLE().putShort(bytes);
+        return putBytes(buffer.array(), 2);
+    }
+
     @Override
-    boolean put32bitsLE(int bytes) {
+    public boolean put32bitsLE(int bytes) {
         bufferLE().putInt(bytes);
         return putBytes(buffer.array(), 4);
     }

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutFile.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutFile.java
@@ -13,22 +13,128 @@ package com.github.mreutegg.laszip4j.laszip;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
-public class ByteStreamOutFile extends ByteStreamOutDataOutput {
+public class ByteStreamOutFile extends ByteStreamOut {
 
-    private RandomAccessFile file;
+    private final RandomAccessFile file;
+    private final ByteBuffer buffer = ByteBuffer.allocate(256 * 1024).order(ByteOrder.LITTLE_ENDIAN);
 
     public ByteStreamOutFile(RandomAccessFile file) {
-        super(file);
         this.file = file;
     }
 
-    public boolean refile(RandomAccessFile file) {
-        if (file == null) {
+    @Override
+    public boolean putByte(byte b) {
+        try {
+            ensureRemainingBufferSize(1);
+            buffer.put(b);
+        } catch (IOException e) {
             return false;
         }
-        this.file = file;
-        this.dataOut = file;
+        return true;
+    }
+
+    @Override
+    public boolean putBytes(byte[] bytes, int u_num_bytes) {
+        try {
+            if (u_num_bytes > buffer.capacity()) {
+                flushBuffer();
+                file.write(bytes, 0, u_num_bytes);
+            } else {
+                ensureRemainingBufferSize(u_num_bytes);
+                buffer.put(bytes, 0, u_num_bytes);
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean put16bitsLE(char bytes) {
+        try {
+            ensureRemainingBufferSize(Character.BYTES);
+            buffer.putChar(bytes);
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean put16bitsLE(short bytes) {
+        try {
+            ensureRemainingBufferSize(Short.BYTES);
+            buffer.putShort(bytes);
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean put32bitsLE(int bytes) {
+        try {
+            ensureRemainingBufferSize(Integer.BYTES);
+            buffer.putInt(bytes);
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean put64bitsLE(long bytes) {
+        try {
+            ensureRemainingBufferSize(Long.BYTES);
+            buffer.putLong(bytes);
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    boolean put16bitsBE(char bytes) {
+        try {
+            ensureRemainingBufferSize(Character.BYTES);
+            buffer.order(ByteOrder.BIG_ENDIAN);
+            buffer.putChar(bytes);
+        } catch (IOException e) {
+            return false;
+        } finally {
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+        }
+        return true;
+    }
+
+    @Override
+    boolean put32bitsBE(int bytes) {
+        try {
+            ensureRemainingBufferSize(Integer.BYTES);
+            buffer.order(ByteOrder.BIG_ENDIAN);
+            buffer.putInt(bytes);
+        } catch (IOException e) {
+            return false;
+        } finally {
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+        }
+        return true;
+    }
+
+    @Override
+    boolean put64bitsBE(long bytes) {
+        try {
+            ensureRemainingBufferSize(Long.BYTES);
+            buffer.order(ByteOrder.BIG_ENDIAN);
+            buffer.putLong(bytes);
+        } catch (IOException e) {
+            return false;
+        } finally {
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+        }
         return true;
     }
 
@@ -40,7 +146,7 @@ public class ByteStreamOutFile extends ByteStreamOutDataOutput {
     @Override
     public long tell() {
         try {
-            return file.getFilePointer();
+            return file.getFilePointer() + buffer.position();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -49,6 +155,7 @@ public class ByteStreamOutFile extends ByteStreamOutDataOutput {
     @Override
     public boolean seek(long position) {
         try {
+            flushBuffer();
             file.seek(position);
             return true;
         } catch (IOException e) {
@@ -59,6 +166,7 @@ public class ByteStreamOutFile extends ByteStreamOutDataOutput {
     @Override
     public boolean seekEnd() {
         try {
+            flushBuffer();
             file.seek(file.length());
             return true;
         } catch (IOException e) {
@@ -68,6 +176,20 @@ public class ByteStreamOutFile extends ByteStreamOutDataOutput {
 
     @Override
     public void close() throws IOException {
+        flushBuffer();
         file.close();
+    }
+
+    private void ensureRemainingBufferSize(int numBytes) throws IOException {
+        if (buffer.remaining() < numBytes) {
+            flushBuffer();
+        }
+    }
+
+    private void flushBuffer() throws IOException {
+        if (buffer.position() > 0) {
+            file.write(buffer.array(), 0, buffer.position());
+            buffer.rewind();
+        }
     }
 }

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutOstream.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/ByteStreamOutOstream.java
@@ -19,7 +19,7 @@ public class ByteStreamOutOstream extends ByteStreamOutDataOutput {
 
     private final CountingOutputStream cOut;
 
-    protected ByteStreamOutOstream(OutputStream out) {
+    public ByteStreamOutOstream(OutputStream out) {
         super(null);
         this.cOut = new CountingOutputStream(out);
         this.dataOut = new DataOutputStream(cOut);

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/IntegerCompressor.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/IntegerCompressor.java
@@ -41,6 +41,10 @@ public class IntegerCompressor {
         this(enc, u_bits, 1, 8, 0);
     }
 
+    public IntegerCompressor(ArithmeticEncoder enc, int u_bits, int u_contexts) {
+        this(enc, u_bits, u_contexts, 8, 0);
+    }
+
     IntegerCompressor(ArithmeticEncoder enc, int u_bits, int u_contexts, int u_bits_high, int u_range)
     {
         assert(enc != null);

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASquantizer.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASquantizer.java
@@ -27,7 +27,7 @@ public class LASquantizer {
     public int get_Y(double y) { if (y >= y_offset) return (int)((y-y_offset)/y_scale_factor+0.5); else return (int)((y-y_offset)/y_scale_factor-0.5); };
     public int get_Z(double z) { if (z >= z_offset) return (int)((z-z_offset)/z_scale_factor+0.5); else return (int)((z-z_offset)/z_scale_factor-0.5); };
 
-    LASquantizer()
+    public LASquantizer()
     {
         x_scale_factor = 0.01;
         y_scale_factor = 0.01;

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_GPSTIME11_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_GPSTIME11_v1.java
@@ -48,7 +48,7 @@ public class LASreadItemCompressed_GPSTIME11_v1 extends LASreadItemCompressed {
         dec.initSymbolModel(m_gpstime_0diff);
         ic_gpstime.initDecompressor();
 
-        last_item = (PointDataRecordGpsTime)seedItem;
+        last_item.GPSTime = ((PointDataRecordGpsTime)seedItem).GPSTime;
     }
 
     @Override

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_GPSTIME11_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_GPSTIME11_v2.java
@@ -64,7 +64,7 @@ public class LASreadItemCompressed_GPSTIME11_v2 extends LASreadItemCompressed {
         for(int i=0;i<last_item.length;i++)
             last_item[i] = new PointDataRecordGpsTime();
             
-        last_item[last] = (PointDataRecordGpsTime)seedItem;
+        last_item[last].GPSTime = ((PointDataRecordGpsTime)seedItem).GPSTime;
     }
 
     @Override
@@ -87,7 +87,7 @@ public class LASreadItemCompressed_GPSTIME11_v2 extends LASreadItemCompressed {
                 next = (next+1)&3;
                 last_item[next].GPSTime = ic_gpstime.decompress((int)(last_item[last].GPSTime >>> 32), 8);
                 last_item[next].GPSTime = (last_item[next].GPSTime << 32);
-                last_item[next].GPSTime |= dec.readInt();
+                last_item[next].GPSTime |= Integer.toUnsignedLong(dec.readInt());
                 last = next;
                 last_gpstime_diff[last] = 0;
                 multi_extreme_counter[last] = 0;

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v1.java
@@ -77,7 +77,7 @@ public class LASreadItemCompressed_POINT10_v1 extends LASreadItemCompressed {
             if (m_user_data[i] != null) dec.initSymbolModel(m_user_data[i]);
         }
 
-        last_item = (PointDataRecordPoint10)seedItem;
+        last_item = new PointDataRecordPoint10((PointDataRecordPoint10)seedItem);
     }
 
     @Override

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT10_v2.java
@@ -92,7 +92,7 @@ public class LASreadItemCompressed_POINT10_v2 extends LASreadItemCompressed {
         ic_z.initDecompressor();
 
         /* init last item */
-        last_item = (PointDataRecordPoint10)seedItem;
+        last_item = new PointDataRecordPoint10((PointDataRecordPoint10)seedItem);
 
         /* but set intensity to zero (for the algorith)*/
         last_item.Intensity = 0;

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
@@ -660,11 +660,7 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
             if (gps_time_change) // if the GPS time has actually changed
             {
                 read_gps_time();
-                long x = contexts[current_context].last_gpstime[contexts[current_context].last];
-                if ( x <= 0 )
-                last_item.GPSTime = last_item.GPSTime;
-                else
-                last_item.GPSTime = x;
+                last_item.GPSTime = contexts[current_context].last_gpstime[contexts[current_context].last];
             }
         }
 
@@ -873,7 +869,7 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
           contexts[current_context].next = (contexts[current_context].next+1)&3;
           contexts[current_context].last_gpstime[contexts[current_context].next] = contexts[current_context].ic_gpstime.decompress((int)(contexts[current_context].last_gpstime[contexts[current_context].last] >>> 32), 8);
           contexts[current_context].last_gpstime[contexts[current_context].next] = (contexts[current_context].last_gpstime[contexts[current_context].next] << 32);
-          contexts[current_context].last_gpstime[contexts[current_context].next] |= dec_gps_time.readInt();
+          contexts[current_context].last_gpstime[contexts[current_context].next] |= Integer.toUnsignedLong(dec_gps_time.readInt());
           contexts[current_context].last = contexts[current_context].next;
           contexts[current_context].last_gpstime_diff[contexts[current_context].last] = 0;
           contexts[current_context].multi_extreme_counter[contexts[current_context].last] = 0; 

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
@@ -848,7 +848,7 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
       
         /* init current context from last item */
       
-        contexts[context].last_item = seedItem;
+        contexts[context].last_item = new PointDataRecordPoint14(seedItem);
         contexts[context].last_item.gps_time_change = false;
             
         contexts[context].unused = false;

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB12_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB12_v1.java
@@ -40,7 +40,7 @@ public class LASreadItemCompressed_RGB12_v1 extends LASreadItemCompressed {
         dec.initSymbolModel(m_byte_used);
         ic_rgb.initDecompressor();
 
-        last_item = (PointDataRecordRGB)seedItem;
+        last_item = new PointDataRecordRGB((PointDataRecordRGB)seedItem);
     }
 
     @Override	

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB12_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB12_v2.java
@@ -56,7 +56,7 @@ public class LASreadItemCompressed_RGB12_v2 extends LASreadItemCompressed {
         dec.initSymbolModel(m_rgb_diff_4);
         dec.initSymbolModel(m_rgb_diff_5);
 
-        last_item = (PointDataRecordRGB)seedItem;
+        last_item = new PointDataRecordRGB((PointDataRecordRGB)seedItem);
     }
 
     @Override

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB14_v3.java
@@ -259,7 +259,7 @@ public class LASreadItemCompressed_RGB14_v3 extends LASreadItemCompressed{
     dec_RGB.initSymbolModel(contexts[context].m_rgb_diff_5);
 
     /* init current context from item */
-    contexts[context].last_item = seedItem;
+    contexts[context].last_item = new PointDataRecordRGB(seedItem);
 
     contexts[context].unused = false;
 

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGBNIR14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGBNIR14_v3.java
@@ -376,7 +376,7 @@ public class LASreadItemCompressed_RGBNIR14_v3 extends LASreadItemCompressed{
 
         /* init current context from item */
 
-        contexts[context].last_item = seedItem;    
+        contexts[context].last_item = new PointDataRecordRgbNIR(seedItem);
         contexts[context].unused = false;
 
         return true;

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_WAVEPACKET13_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_WAVEPACKET13_v1.java
@@ -63,7 +63,7 @@ public class LASreadItemCompressed_WAVEPACKET13_v1 extends LASreadItemCompressed
         ic_xyz.initDecompressor();
 
         /* init last item */
-        last_item = (PointDataRecordWavepacket)seedItem;
+        last_item = new PointDataRecordWavepacket((PointDataRecordWavepacket)seedItem);
     }
 
     public PointDataRecord read(int notUsed)

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_WAVEPACKET14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_WAVEPACKET14_v3.java
@@ -231,7 +231,7 @@ public class LASreadItemCompressed_WAVEPACKET14_v3 extends LASreadItemCompressed
 
         contexts[context].last_diff_32 = 0;
         contexts[context].sym_last_offset_diff = 0;
-        contexts[context].last_item = seedItem;
+        contexts[context].last_item = new PointDataRecordWavepacket(seedItem);
 
         contexts[context].unused = false;
 

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemRaw_WAVEPACKET13.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemRaw_WAVEPACKET13.java
@@ -23,9 +23,9 @@ public class LASreadItemRaw_WAVEPACKET13 extends LASreadItemRaw {
         instream.getBytes(bb.array(), 29);
 
         PointDataRecordWavepacket result = new PointDataRecordWavepacket();
-        result.DescriptorIndex = bb.get();
+        result.DescriptorIndex = (short) Byte.toUnsignedInt(bb.get());
         result.OffsetToWaveformData = bb.getLong();
-        result.PacketSize = bb.getInt();
+        result.PacketSize = Integer.toUnsignedLong(bb.getInt());
         result.ReturnPointWaveformLocation = bb.getFloat();
         result.ParametricDx = bb.getFloat();
         result.ParametricDy = bb.getFloat();

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItem.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItem.java
@@ -1,0 +1,16 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public abstract class LASwriteItem<T extends PointDataRecord> {
+
+    public abstract boolean write(T point, int /* unsigned */ context);
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed.java
@@ -1,0 +1,26 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+import static java.lang.Boolean.FALSE;
+
+public abstract class LASwriteItemCompressed extends LASwriteItem<PointDataRecord> {
+
+    public abstract boolean init(PointDataRecord point, int context);
+
+    public boolean chunk_sizes() {
+        return FALSE;
+    }
+
+    public boolean chunk_bytes() {
+        return FALSE;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE14_v3.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_BYTE14_v3 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_BYTE14_v3(ArithmeticEncoder enc, char size) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE14_v4.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE14_v4.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_BYTE14_v4 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_BYTE14_v4(ArithmeticEncoder enc, char size) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE_v1.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_BYTE_v1 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_BYTE_v1(ArithmeticEncoder enc, char size) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_BYTE_v2.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_BYTE_v2 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_BYTE_v2(ArithmeticEncoder enc, char size) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_GPSTIME11_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_GPSTIME11_v1.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_GPSTIME11_v1 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_GPSTIME11_v1(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_GPSTIME11_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_GPSTIME11_v2.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_GPSTIME11_v2 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_GPSTIME11_v2(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT10_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT10_v1.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_POINT10_v1 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_POINT10_v1(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT10_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT10_v2.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_POINT10_v2 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_POINT10_v2(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT14_v3.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_POINT14_v3 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_POINT14_v3(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT14_v4.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_POINT14_v4.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_POINT14_v4 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_POINT14_v4(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB12_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB12_v1.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_RGB12_v1 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_RGB12_v1(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB12_v2.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB12_v2.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_RGB12_v2 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_RGB12_v2(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB14_v3.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_RGB14_v3 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_RGB14_v3(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB14_v4.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGB14_v4.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_RGB14_v4 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_RGB14_v4(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGBNIR14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGBNIR14_v3.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_RGBNIR14_v3 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_RGBNIR14_v3(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGBNIR14_v4.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_RGBNIR14_v4.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_RGBNIR14_v4 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_RGBNIR14_v4(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_WAVEPACKET13_v1.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_WAVEPACKET13_v1.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_WAVEPACKET13_v1 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_WAVEPACKET13_v1(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_WAVEPACKET14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_WAVEPACKET14_v3.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_WAVEPACKET14_v3 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_WAVEPACKET14_v3(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_WAVEPACKET14_v4.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemCompressed_WAVEPACKET14_v4.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+// TODO: only dummy implementation
+public class LASwriteItemCompressed_WAVEPACKET14_v4 extends LASwriteItemCompressed {
+    public LASwriteItemCompressed_WAVEPACKET14_v4(ArithmeticEncoder enc) {
+    }
+
+    @Override
+    public boolean write(PointDataRecord point, int context) {
+        return false;
+    }
+
+    @Override
+    public boolean init(PointDataRecord point, int context) {
+        return false;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw.java
@@ -1,0 +1,27 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+public abstract class LASwriteItemRaw<T extends PointDataRecord> extends LASwriteItem<T> {
+
+    protected ByteStreamOut outstream;
+
+    public boolean init(ByteStreamOut outstream) {
+        if (outstream == null) {
+            return FALSE;
+        }
+        this.outstream = outstream;
+        return TRUE;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_BYTE.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_BYTE.java
@@ -1,0 +1,25 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public class LASwriteItemRaw_BYTE extends LASwriteItemRaw<PointDataRecordBytes> {
+
+    private final int byteCount;
+
+    public LASwriteItemRaw_BYTE(int byteCount) {
+        this.byteCount = byteCount;
+    }
+
+    @Override
+    public boolean write(PointDataRecordBytes point, int context) {
+        return outstream.putBytes(point.Bytes, byteCount);
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_GPSTIME11.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_GPSTIME11.java
@@ -1,0 +1,19 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public class LASwriteItemRaw_GPSTIME11 extends LASwriteItemRaw<PointDataRecordGpsTime> {
+    @Override
+    public boolean write(PointDataRecordGpsTime point, int context) {
+        outstream.put64bitsLE(point.GPSTime);
+        return true;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_POINT10.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_POINT10.java
@@ -1,0 +1,28 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public class LASwriteItemRaw_POINT10 extends LASwriteItemRaw<PointDataRecordPoint10> {
+
+    @Override
+    public boolean write(PointDataRecordPoint10 point, int /* unsigned */ context) {
+        outstream.put32bitsLE(point.X);
+        outstream.put32bitsLE(point.Y);
+        outstream.put32bitsLE(point.Z);
+        outstream.put16bitsLE(point.Intensity);
+        outstream.putByte(point.Flags);
+        outstream.putByte((byte) point.Classification);
+        outstream.putByte(point.ScanAngleRank);
+        outstream.putByte((byte) point.UserData);
+        outstream.put16bitsLE(point.PointSourceID);
+        return true;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_POINT14.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_POINT14.java
@@ -1,0 +1,29 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public class LASwriteItemRaw_POINT14 extends LASwriteItemRaw<PointDataRecordPoint14> {
+    @Override
+    public boolean write(PointDataRecordPoint14 point, int context) {
+        outstream.put32bitsLE(point.X);
+        outstream.put32bitsLE(point.Y);
+        outstream.put32bitsLE(point.Z);
+        outstream.put16bitsLE(point.Intensity);
+        outstream.putByte(point.ReturnFlags);
+        outstream.putByte(point.ScanFlags);
+        outstream.putByte((byte) point.Classification);
+        outstream.putByte((byte) point.UserData);
+        outstream.put16bitsLE(point.ScanAngle);
+        outstream.put16bitsLE(point.PointSourceID);
+        outstream.put64bitsLE(point.GPSTime);
+        return true;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_RGB12.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_RGB12.java
@@ -1,0 +1,21 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public class LASwriteItemRaw_RGB12 extends LASwriteItemRaw<PointDataRecordRGB> {
+    @Override
+    public boolean write(PointDataRecordRGB point, int context) {
+        outstream.put16bitsLE(point.R);
+        outstream.put16bitsLE(point.G);
+        outstream.put16bitsLE(point.B);
+        return true;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_RGBNIR14.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_RGBNIR14.java
@@ -1,0 +1,22 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public class LASwriteItemRaw_RGBNIR14 extends LASwriteItemRaw<PointDataRecordRgbNIR> {
+    @Override
+    public boolean write(PointDataRecordRgbNIR point, int context) {
+        outstream.put16bitsLE(point.R);
+        outstream.put16bitsLE(point.G);
+        outstream.put16bitsLE(point.B);
+        outstream.put16bitsLE(point.NIR);
+        return true;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_WAVEPACKET13.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwriteItemRaw_WAVEPACKET13.java
@@ -1,0 +1,25 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+public class LASwriteItemRaw_WAVEPACKET13 extends LASwriteItemRaw<PointDataRecordWavepacket> {
+    @Override
+    public boolean write(PointDataRecordWavepacket point, int context) {
+        outstream.putByte((byte) point.DescriptorIndex);
+        outstream.put64bitsLE(point.OffsetToWaveformData);
+        outstream.put32bitsLE((int) point.PacketSize);
+        outstream.put32bitsLE(Float.floatToIntBits(point.ReturnPointWaveformLocation));
+        outstream.put32bitsLE(Float.floatToIntBits(point.ParametricDx));
+        outstream.put32bitsLE(Float.floatToIntBits(point.ParametricDy));
+        outstream.put32bitsLE(Float.floatToIntBits(point.ParametricDz));
+        return true;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwritePoint.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwritePoint.java
@@ -1,0 +1,451 @@
+/*
+ * (c) 2007-2022, rapidlasso GmbH - fast tools to catch reality
+ *
+ * This is free software; you can redistribute and/or modify it under the
+ * terms of the Apache Public License 2.0 published by the Apache Software
+ * Foundation. See the COPYING file for more information.
+ *
+ * This software is distributed WITHOUT ANY WARRANTY and without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package com.github.mreutegg.laszip4j.laszip;
+
+import static com.github.mreutegg.laszip4j.laszip.LASzip.*;
+import static com.github.mreutegg.laszip4j.laszip.MyDefs.U32_MAX;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+public class LASwritePoint {
+
+    private ByteStreamOut outstream;
+    private int num_writers;                // unsigned
+    private LASwriteItem[] writers;
+    private LASwriteItemRaw[] writers_raw;
+    private LASwriteItemCompressed[] writers_compressed;
+    private ArithmeticEncoder enc;
+    private boolean layered_las14_compression;
+    // used for chunking
+    private int chunk_size;                 // unsigned
+    private int chunk_count;                // unsigned
+    private int number_chunks;              // unsigned
+    private int alloced_chunks;             // unsigned
+    private int[] chunk_sizes;              // unsigned
+    private int[] chunk_bytes;              // unsigned
+    private long chunk_start_position;
+    private long chunk_table_start_position;
+    private boolean add_chunk_to_table() {
+        if (number_chunks == alloced_chunks)
+        {
+            if (chunk_bytes == null)
+            {
+                alloced_chunks = 1024;
+                if (chunk_size == U32_MAX) chunk_sizes = new int[alloced_chunks];
+                chunk_bytes = new int[alloced_chunks];
+            }
+            else
+            {
+                alloced_chunks *= 2;
+                if (chunk_size == U32_MAX) chunk_sizes = new int[alloced_chunks];
+                chunk_bytes = new int[alloced_chunks];
+            }
+        }
+        long position = outstream.tell();
+        if (chunk_size == U32_MAX) chunk_sizes[number_chunks] = chunk_count;
+        chunk_bytes[number_chunks] = (int) (position - chunk_start_position);
+        chunk_start_position = position;
+        number_chunks++;
+        return TRUE;
+    }
+    private boolean write_chunk_table() {
+        int i; // unsigned
+        long position = outstream.tell();
+        if (chunk_table_start_position != -1) // stream is seekable
+        {
+            if (!outstream.seek(chunk_table_start_position))
+            {
+                return FALSE;
+            }
+            if (!outstream.put64bitsLE(position))
+            {
+                return FALSE;
+            }
+            if (!outstream.seek(position))
+            {
+                return FALSE;
+            }
+        }
+        int version = 0; // unsigned
+        if (!outstream.put32bitsLE(version))
+        {
+            return FALSE;
+        }
+        if (!outstream.put32bitsLE(number_chunks))
+        {
+            return FALSE;
+        }
+        if (number_chunks > 0)
+        {
+            enc.init(outstream);
+            IntegerCompressor ic = new IntegerCompressor(enc, 32, 2);
+            ic.initCompressor();
+            for (i = 0; Integer.compareUnsigned(i, number_chunks) < 0; i++)
+            {
+                if (chunk_size == U32_MAX) ic.compress((i != 0 ? chunk_sizes[i-1] : 0), chunk_sizes[i], 0);
+                ic.compress((i != 0 ? chunk_bytes[i-1] : 0), chunk_bytes[i], 1);
+            }
+            enc.done();
+        }
+        if (chunk_table_start_position == -1) // stream is not-seekable
+        {
+            if (!outstream.put64bitsLE(position))
+            {
+                return FALSE;
+            }
+        }
+        return TRUE;
+    }
+
+    public boolean setup(int /* unsigned */ num_items, LASitem[] items) {
+        return setup(num_items, items, null);
+    }
+
+    // should only be called *once*
+    public boolean setup(int /* unsigned */ num_items, LASitem[] items, LASzip laszip) {
+        int i;
+
+        // is laszip exists then we must use its items
+        if (laszip != null)
+        {
+            if (num_items == 0) return FALSE;
+            if (items == null) return FALSE;
+            if (num_items != laszip.num_items) return FALSE;
+            if (items != laszip.items) return FALSE;
+        }
+
+        // create entropy encoder (if requested)
+        enc = null;
+        if (laszip != null && laszip.compressor != 0)
+        {
+            switch (laszip.coder)
+            {
+                case LASZIP_CODER_ARITHMETIC:
+                    enc = new ArithmeticEncoder();
+                    break;
+                default:
+                    // entropy decoder not supported
+                    return FALSE;
+            }
+            // maybe layered compression for LAS 1.4
+            layered_las14_compression = (laszip.compressor == LASZIP_COMPRESSOR_LAYERED_CHUNKED);
+        }
+
+        // initizalize the writers
+        writers = null;
+        num_writers = num_items;
+
+        // disable chunking
+        chunk_size = U32_MAX;
+
+        // always create the raw writers
+        writers_raw = new LASwriteItemRaw[num_writers];
+        for (i = 0; Integer.compareUnsigned(i, num_writers) < 0; i++)
+        {
+            switch (items[i].type)
+            {
+                case POINT10:
+                    writers_raw[i] = new LASwriteItemRaw_POINT10();
+                    break;
+                case GPSTIME11:
+                    writers_raw[i] = new LASwriteItemRaw_GPSTIME11();
+                    break;
+                case RGB12:
+                case RGB14:
+                    writers_raw[i] = new LASwriteItemRaw_RGB12();
+                    break;
+                case BYTE:
+                case BYTE14:
+                    writers_raw[i] = new LASwriteItemRaw_BYTE(items[i].size);
+                    break;
+                case POINT14:
+                    writers_raw[i] = new LASwriteItemRaw_POINT14();
+                    break;
+                case RGBNIR14:
+                    writers_raw[i] = new LASwriteItemRaw_RGBNIR14();
+                    break;
+                case WAVEPACKET13:
+                case WAVEPACKET14:
+                    writers_raw[i] = new LASwriteItemRaw_WAVEPACKET13();
+                    break;
+                default:
+                    return FALSE;
+            }
+        }
+
+        // if needed create the compressed writers and set versions
+        if (enc != null)
+        {
+            writers_compressed = new LASwriteItemCompressed[num_writers];
+            for (i = 0; i < num_writers; i++)
+            {
+                switch (items[i].type)
+                {
+                    case POINT10:
+                        if (items[i].version == 1)
+                            writers_compressed[i] = new LASwriteItemCompressed_POINT10_v1(enc);
+                        else if (items[i].version == 2)
+                            writers_compressed[i] = new LASwriteItemCompressed_POINT10_v2(enc);
+                        else
+                            return FALSE;
+                        break;
+                    case GPSTIME11:
+                        if (items[i].version == 1)
+                            writers_compressed[i] = new LASwriteItemCompressed_GPSTIME11_v1(enc);
+                        else if (items[i].version == 2)
+                            writers_compressed[i] = new LASwriteItemCompressed_GPSTIME11_v2(enc);
+                        else
+                            return FALSE;
+                        break;
+                    case RGB12:
+                        if (items[i].version == 1)
+                            writers_compressed[i] = new LASwriteItemCompressed_RGB12_v1(enc);
+                        else if (items[i].version == 2)
+                            writers_compressed[i] = new LASwriteItemCompressed_RGB12_v2(enc);
+                        else
+                            return FALSE;
+                        break;
+                    case BYTE:
+                        if (items[i].version == 1)
+                            writers_compressed[i] = new LASwriteItemCompressed_BYTE_v1(enc, items[i].size);
+                        else if (items[i].version == 2)
+                            writers_compressed[i] = new LASwriteItemCompressed_BYTE_v2(enc, items[i].size);
+                        else
+                            return FALSE;
+                        break;
+                    case POINT14:
+                        if (items[i].version == 3)
+                            writers_compressed[i] = new LASwriteItemCompressed_POINT14_v3(enc);
+                        else if (items[i].version == 4)
+                            writers_compressed[i] = new LASwriteItemCompressed_POINT14_v4(enc);
+                        else
+                            return FALSE;
+                        break;
+                    case RGB14:
+                        if (items[i].version == 3)
+                            writers_compressed[i] = new LASwriteItemCompressed_RGB14_v3(enc);
+                        else if (items[i].version == 4)
+                            writers_compressed[i] = new LASwriteItemCompressed_RGB14_v4(enc);
+                        else
+                            return FALSE;
+                        break;
+                    case RGBNIR14:
+                        if (items[i].version == 3)
+                            writers_compressed[i] = new LASwriteItemCompressed_RGBNIR14_v3(enc);
+                        else if (items[i].version == 4)
+                            writers_compressed[i] = new LASwriteItemCompressed_RGBNIR14_v4(enc);
+                        else
+                            return FALSE;
+                        break;
+                    case BYTE14:
+                        if (items[i].version == 3)
+                            writers_compressed[i] = new LASwriteItemCompressed_BYTE14_v3(enc, items[i].size);
+                        else if (items[i].version == 4)
+                            writers_compressed[i] = new LASwriteItemCompressed_BYTE14_v4(enc, items[i].size);
+                        else
+                            return FALSE;
+                        break;
+                    case WAVEPACKET13:
+                        if (items[i].version == 1)
+                            writers_compressed[i] = new LASwriteItemCompressed_WAVEPACKET13_v1(enc);
+                        else
+                            return FALSE;
+                        break;
+                    case WAVEPACKET14:
+                        if (items[i].version == 3)
+                            writers_compressed[i] = new LASwriteItemCompressed_WAVEPACKET14_v3(enc);
+                        else if (items[i].version == 4)
+                            writers_compressed[i] = new LASwriteItemCompressed_WAVEPACKET14_v4(enc);
+                        else
+                            return FALSE;
+                        break;
+                    default:
+                        return FALSE;
+                }
+            }
+            if (laszip.compressor != LASZIP_COMPRESSOR_POINTWISE)
+            {
+                if (laszip.chunk_size != 0) chunk_size = laszip.chunk_size;
+                chunk_count = 0;
+                number_chunks = U32_MAX;
+            }
+        }
+        return TRUE;
+    }
+
+    public boolean init(ByteStreamOut outstream) {
+        if (outstream == null) return FALSE;
+        this.outstream = outstream;
+
+        // if chunking is enabled
+        if (number_chunks == U32_MAX)
+        {
+            number_chunks = 0;
+            if (outstream.isSeekable())
+            {
+                chunk_table_start_position = outstream.tell();
+            }
+            else
+            {
+                chunk_table_start_position = -1;
+            }
+            outstream.put64bitsLE(chunk_table_start_position);
+            chunk_start_position = outstream.tell();
+        }
+
+        int i; // unsigned
+        for (i = 0; Integer.compareUnsigned(i, num_writers) < 0; i++)
+        {
+            writers_raw[i].init(outstream);
+        }
+
+        if (enc != null)
+        {
+            writers = null;
+        }
+        else
+        {
+            writers = writers_raw;
+        }
+
+        return TRUE;
+    }
+    public boolean write(PointDataRecord[] pointRecords) {
+        int i; // unsigned
+        int context = 0; // unsigned
+
+        if (chunk_count == chunk_size)
+        {
+            if (enc != null)
+            {
+                if (layered_las14_compression)
+                {
+                    // write how many points are in the chunk
+                    outstream.put32bitsLE(chunk_count);
+                    // write all layers
+                    for (i = 0; i < num_writers; i++)
+                    {
+                        ((LASwriteItemCompressed)writers[i]).chunk_sizes();
+                    }
+                    for (i = 0; i < num_writers; i++)
+                    {
+                        ((LASwriteItemCompressed)writers[i]).chunk_bytes();
+                    }
+                }
+                else
+                {
+                    enc.done();
+                }
+                add_chunk_to_table();
+                init(outstream);
+            }
+            else
+            {
+                // happens *only* for uncompressed LAS with over U32_MAX points
+                assert(chunk_size == U32_MAX);
+            }
+            chunk_count = 0;
+        }
+        chunk_count++;
+
+        if (writers != null)
+        {
+            for (i = 0; i < num_writers; i++)
+            {
+                if (!writers[i].write(pointRecords[i], context))
+                {
+                    return FALSE;
+                }
+            }
+        }
+        else
+        {
+            for (i = 0; i < num_writers; i++)
+            {
+                if (!writers_raw[i].write(pointRecords[i], context))
+                {
+                    return FALSE;
+                }
+                writers_compressed[i].init(pointRecords[i], context);
+            }
+            writers = writers_compressed;
+            enc.init(outstream);
+        }
+        return TRUE;
+    }
+    public boolean chunk() {
+        if (chunk_start_position == 0 || chunk_size != U32_MAX)
+        {
+            return FALSE;
+        }
+        if (layered_las14_compression)
+        {
+            int i; // unsigned
+            // write how many points are in the chunk
+            outstream.put32bitsLE(chunk_count);
+            // write all layers
+            for (i = 0; Integer.compareUnsigned(i, num_writers) < 0; i++)
+            {
+                ((LASwriteItemCompressed)writers[i]).chunk_sizes();
+            }
+            for (i = 0; i < num_writers; i++)
+            {
+                ((LASwriteItemCompressed)writers[i]).chunk_bytes();
+            }
+        }
+        else
+        {
+            enc.done();
+        }
+        add_chunk_to_table();
+        init(outstream);
+        chunk_count = 0;
+        return TRUE;
+    }
+    public boolean done() {
+        if (writers == writers_compressed)
+        {
+            if (layered_las14_compression)
+            {
+                int i; // unsigned
+                // write how many points are in the chunk
+                outstream.put32bitsLE(chunk_count);
+                // write all layers
+                for (i = 0; i < num_writers; i++)
+                {
+                    ((LASwriteItemCompressed)writers[i]).chunk_sizes();
+                }
+                for (i = 0; i < num_writers; i++)
+                {
+                    ((LASwriteItemCompressed)writers[i]).chunk_bytes();
+                }
+            }
+            else
+            {
+                enc.done();
+            }
+            if (chunk_start_position != 0)
+            {
+                if (chunk_count != 0) add_chunk_to_table();
+                return write_chunk_table();
+            }
+        }
+        else if (writers == null)
+        {
+            if (chunk_start_position != 0)
+            {
+                return write_chunk_table();
+            }
+        }
+
+        return TRUE;
+    }
+}

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwritePoint.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASwritePoint.java
@@ -377,6 +377,7 @@ public class LASwritePoint {
                 writers_compressed[i].init(pointRecords[i], context);
             }
             writers = writers_compressed;
+            assert(enc != null);
             enc.init(outstream);
         }
         return TRUE;

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASzip.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASzip.java
@@ -352,7 +352,7 @@ public class LASzip {
         return true;
     }
 
-    boolean setup(char num_items, LASitem[] items, char compressor)
+    public boolean setup(char num_items, LASitem[] items, char compressor)
     {
         // check input
         if (!check_compressor(compressor)) return false;
@@ -577,7 +577,7 @@ public class LASzip {
         return true;
     }
 
-    boolean set_chunk_size(int u_chunk_size)
+    public boolean set_chunk_size(int u_chunk_size)
     {
         if (num_items == 0) return return_error("call setup() before setting chunk size");
         if (this.compressor == LASZIP_COMPRESSOR_POINTWISE_CHUNKED)
@@ -588,7 +588,7 @@ public class LASzip {
         return false;
     }
 
-    boolean request_version(char requested_version)
+    public boolean request_version(char requested_version)
     {
         if (num_items == 0) return return_error("call setup() before requesting version");
         if (compressor == LASZIP_COMPRESSOR_NONE)
@@ -625,7 +625,7 @@ public class LASzip {
         return true;
     }
 
-    boolean is_standard(byte[] point_type, char[] record_length)
+    public boolean is_standard(byte[] point_type, char[] record_length)
     {
         return is_standard(num_items, items, point_type, record_length);
     }

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/MyDefs.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/MyDefs.java
@@ -10,7 +10,7 @@
  */
 package com.github.mreutegg.laszip4j.laszip;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 public interface MyDefs {
 
@@ -78,11 +78,7 @@ public interface MyDefs {
     }
 
     static byte[] asByteArray(String s) {
-        try {
-            return s.getBytes("US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return s.getBytes(StandardCharsets.US_ASCII);
     }
 
     static String stringFromByteArray(byte[] bytes) {
@@ -93,14 +89,10 @@ public interface MyDefs {
                 break;
             }
         }
-        try {
-            if (idx != -1) {
-                return new String(bytes, 0, idx, "US-ASCII");
-            } else {
-                return new String(bytes, "US-ASCII");
-            }
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+        if (idx != -1) {
+            return new String(bytes, 0, idx, StandardCharsets.US_ASCII);
+        } else {
+            return new String(bytes, StandardCharsets.US_ASCII);
         }
     }
 

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/PointDataRecords.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/PointDataRecords.java
@@ -209,6 +209,15 @@ class PointDataRecordRGB extends PointDataRecord {
     public char G = 0;
     public char B = 0;
 
+    public PointDataRecordRGB() {
+    }
+
+    public PointDataRecordRGB(PointDataRecordRGB other) {
+        this.R = other.R;
+        this.G = other.G;
+        this.B = other.B;
+    }
+
     public char[] getRGB() {
         return new char[]{(char)R,(char)G,(char)B};
     }
@@ -462,6 +471,15 @@ class PointDataRecordPoint14 extends PointDataRecordXYZBase implements IGpsTimeP
 class PointDataRecordRgbNIR extends PointDataRecordRGB {
 
     public char NIR = 0;
+
+    public PointDataRecordRgbNIR() {
+
+    }
+
+    public PointDataRecordRgbNIR(PointDataRecordRgbNIR other) {
+        super(other);
+        this.NIR = other.NIR;
+    }
 
     @Override
     public String toString()

--- a/src/test/java/com/github/mreutegg/laszip4j/DataFiles.java
+++ b/src/test/java/com/github/mreutegg/laszip4j/DataFiles.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Marcel Reutegger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.mreutegg.laszip4j;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+
+public class DataFiles {
+
+    public static final String LAZ_NAME = "26690_12570.laz";
+    private static final String LAZ_BASE_URL = "http://maps.zh.ch/download/hoehen/2014/lidar";
+    public static final int LAZ_NUM_POINT_RECORDS = 265401;
+
+    public static final String LAS_NAME = "2312.las";
+    private static final String LAS_BASE_URL = "https://dc-lidar-2018.s3.amazonaws.com/Classified_LAS";
+    public static final int LAS_NUM_POINT_RECORDS = 1653361;
+
+    public static final String LAZ_14_NAME = "autzen-classified.copc.laz";
+    private static final String LAZ_14_BASE_URL = "https://github.com/PDAL/data/raw/master/autzen";
+    public static final int LAZ_14_NUM_POINT_RECORDS = 10653336;
+
+    private final File target = new File("target");
+    public final File laz = new File(target, LAZ_NAME);
+    public final File las = new File(target, LAS_NAME);
+    public final File laz14 = new File(target, LAZ_14_NAME);
+
+    public void download() throws Exception {
+        if (!laz.exists()) {
+            URI url = new URI(LAZ_BASE_URL + "/" + LAZ_NAME);
+            try (CloseableHttpClient client = HttpClients.createDefault()) {
+                try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+                    try (OutputStream out = Files.newOutputStream(laz.toPath())) {
+                        response.getEntity().writeTo(out);
+                    }
+                }
+            }
+        }
+        if (!las.exists()) {
+            URI url = new URI(LAS_BASE_URL + "/" + LAS_NAME);
+            try (CloseableHttpClient client = HttpClients.createDefault()) {
+                try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+                    try (OutputStream out = Files.newOutputStream(las.toPath())) {
+                        response.getEntity().writeTo(out);
+                    }
+                }
+            }
+        }
+        if (!laz14.exists()) {
+            URI url = new URI(LAZ_14_BASE_URL + "/" + LAZ_14_NAME);
+            try (CloseableHttpClient client = HttpClients.createDefault()) {
+                try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+                    try (OutputStream out = Files.newOutputStream(laz14.toPath())) {
+                        response.getEntity().writeTo(out);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/mreutegg/laszip4j/LASReaderTest.java
+++ b/src/test/java/com/github/mreutegg/laszip4j/LASReaderTest.java
@@ -45,7 +45,11 @@ public class LASReaderTest {
 
     @Test
     public void readLaz14() {
-        LASReader reader = new LASReader(files.laz14);
+        verifyLaz14(files.laz14);
+    }
+
+    public static void verifyLaz14(File file) {
+        LASReader reader = new LASReader(file);
         LASHeader header = reader.getHeader();
 
         assertEquals(header.getNumberOfVariableLengthRecords(), StreamSupport.stream(header.getVariableLengthRecords().spliterator(), false).count());

--- a/src/test/java/com/github/mreutegg/laszip4j/LASReaderTest.java
+++ b/src/test/java/com/github/mreutegg/laszip4j/LASReaderTest.java
@@ -16,81 +16,36 @@
  */
 package com.github.mreutegg.laszip4j;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.*;
-import java.net.URI;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.github.mreutegg.laszip4j.DataFiles.LAS_NUM_POINT_RECORDS;
+import static com.github.mreutegg.laszip4j.DataFiles.LAZ_14_NUM_POINT_RECORDS;
+import static com.github.mreutegg.laszip4j.DataFiles.LAZ_NUM_POINT_RECORDS;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class LASReaderTest {
 
-    private static final String LAZ_NAME = "26690_12570.laz";
-    private static final String LAZ_BASE_URL = "http://maps.zh.ch/download/hoehen/2014/lidar";
-    private static final int LAZ_NUM_POINT_RECORDS = 265401;
-
-    private static final String LAS_NAME = "2312.las";
-    private static final String LAS_BASE_URL = "https://dc-lidar-2018.s3.amazonaws.com/Classified_LAS";
-    private static final int LAS_NUM_POINT_RECORDS = 1653361;
-
-    private static final String LAZ_14_NAME = "autzen-classified.copc.laz";
-    private static final String LAZ_14_BASE_URL = "https://github.com/PDAL/data/raw/master/autzen";
-    private static final int LAZ_14_NUM_POINT_RECORDS = 10653336;
-
-    private final File target = new File("target");
-    private final File laz = new File(target, LAZ_NAME);
-    private final File las = new File(target, LAS_NAME);
-
-    private final File laz14 = new File(target, LAZ_14_NAME);
+    private final DataFiles files = new DataFiles();
 
     @Before
     public void before() throws Exception {
-        if (!laz.exists()) {
-            URI url = new URI(LAZ_BASE_URL + "/" + LAZ_NAME);
-            try (CloseableHttpClient client = HttpClients.createDefault()) {
-                try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
-                    try (OutputStream out = new FileOutputStream(laz)) {
-                        response.getEntity().writeTo(out);
-                    }
-                }
-            }
-        }
-        if (!las.exists()) {
-            URI url = new URI(LAS_BASE_URL + "/" + LAS_NAME);
-            try (CloseableHttpClient client = HttpClients.createDefault()) {
-                try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
-                    try (OutputStream out = new FileOutputStream(las)) {
-                        response.getEntity().writeTo(out);
-                    }
-                }
-            }
-        }
-        if (!laz14.exists()) {
-            URI url = new URI(LAZ_14_BASE_URL + "/" + LAZ_14_NAME);
-            try (CloseableHttpClient client = HttpClients.createDefault()) {
-                try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
-                    try (OutputStream out = new FileOutputStream(laz14)) {
-                        response.getEntity().writeTo(out);
-                    }
-                }
-            }
-        }
+        files.download();
     }
 
     @Test
     public void readLaz14() {
-        LASReader reader = new LASReader(laz14);
+        LASReader reader = new LASReader(files.laz14);
         LASHeader header = reader.getHeader();
 
         assertEquals(header.getNumberOfVariableLengthRecords(), StreamSupport.stream(header.getVariableLengthRecords().spliterator(), false).count());
@@ -129,7 +84,11 @@ public class LASReaderTest {
 
     @Test
     public void read() {
-        LASReader reader = new LASReader(laz);
+        verifyLaz(files.laz);
+    }
+
+    public static void verifyLaz(File file) {
+        LASReader reader = new LASReader(file);
         LASHeader header = reader.getHeader();
 
         assertEquals(header.getNumberOfVariableLengthRecords(), StreamSupport.stream(header.getVariableLengthRecords().spliterator(), false).count());
@@ -153,7 +112,7 @@ public class LASReaderTest {
 
     @Test
     public void readLAS() {
-        LASReader reader = new LASReader(las);
+        LASReader reader = new LASReader(files.las);
         LASHeader header = reader.getHeader();
 
         long[] classifications = new long[Byte.MAX_VALUE];
@@ -256,7 +215,7 @@ public class LASReaderTest {
     @Test
     public void readLASStream() throws Exception {
         LASHeader header;
-        try (InputStream is = new FileInputStream(las)) {
+        try (InputStream is = Files.newInputStream(files.las.toPath())) {
             header = LASReader.getHeader(is);
         }
 
@@ -319,7 +278,7 @@ public class LASReaderTest {
         double maxGpsTime = Double.MIN_VALUE;
         double minGpsTime = Double.MAX_VALUE;
         long numPoints = 0;
-        try (InputStream is = new FileInputStream(las)) {
+        try (InputStream is = Files.newInputStream(files.las.toPath())) {
             for (LASPoint p : LASReader.getPoints(is)) {
                 classifications[p.getClassification()]++;
                 minX = Math.min(minX, p.getX());
@@ -361,7 +320,7 @@ public class LASReaderTest {
 
     @Test
     public void insideTile() {
-        LASReader reader = new LASReader(laz)
+        LASReader reader = new LASReader(files.laz)
                 .insideTile(2669450, 1257400, 40);
 
         int minX = Integer.MAX_VALUE;
@@ -389,7 +348,7 @@ public class LASReaderTest {
 
     @Test
     public void insideRectangle() {
-        LASReader reader = new LASReader(laz)
+        LASReader reader = new LASReader(files.laz)
                 .insideRectangle(2669450, 1257390, 2669480, 1257450);
 
         int minX = Integer.MAX_VALUE;
@@ -417,7 +376,7 @@ public class LASReaderTest {
 
     @Test
     public void insideCircle() {
-        LASReader reader = new LASReader(laz)
+        LASReader reader = new LASReader(files.laz)
                 .insideCircle(2669465, 1257440, 20);
 
         int minX = Integer.MAX_VALUE;

--- a/src/test/java/com/github/mreutegg/laszip4j/laslib/LASwriterLASTest.java
+++ b/src/test/java/com/github/mreutegg/laszip4j/laslib/LASwriterLASTest.java
@@ -30,6 +30,8 @@ public class LASwriterLASTest {
 
     private final File las = new File("target", files.laz.getName() + LASwriterLASTest.class.getName() + ".las");
 
+    private final File las14 = new File("target", files.laz14.getName() + LASwriterLASTest.class.getName() + ".las");
+
     @Before
     public void before() throws Exception {
         files.download();
@@ -39,5 +41,11 @@ public class LASwriterLASTest {
     public void writeLas() {
         Laszip.run(new String[]{"-i", files.laz.getPath(), "-o", las.getPath()});
         LASReaderTest.verifyLaz(las);
+    }
+
+    @Test
+    public void writeLas14() {
+        Laszip.run(new String[]{"-i", files.laz14.getPath(), "-o", las14.getPath()});
+        LASReaderTest.verifyLaz14(las14);
     }
 }

--- a/src/test/java/com/github/mreutegg/laszip4j/laslib/LASwriterLASTest.java
+++ b/src/test/java/com/github/mreutegg/laszip4j/laslib/LASwriterLASTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Marcel Reutegger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.mreutegg.laszip4j.laslib;
+
+import com.github.mreutegg.laszip4j.DataFiles;
+import com.github.mreutegg.laszip4j.LASReaderTest;
+import com.github.mreutegg.laszip4j.lastools.Laszip;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+public class LASwriterLASTest {
+
+    private final DataFiles files = new DataFiles();
+
+    private final File las = new File("target", files.laz.getName() + LASwriterLASTest.class.getName() + ".las");
+
+    @Before
+    public void before() throws Exception {
+        files.download();
+    }
+
+    @Test
+    public void writeLas() {
+        Laszip.run(new String[]{"-i", files.laz.getPath(), "-o", las.getPath()});
+        LASReaderTest.verifyLaz(las);
+    }
+}


### PR DESCRIPTION
The changes in this PR introduce support for writing las files.

So far I tested these changes by reading a laz file and writing data into las format with the following command.
```
java -jar laszip4j-0.13-SNAPSHOT.jar -i 26690_12570.laz -o 26690_12570.las
```
Then compared the result with the output from running the same with the native/original laszip tool.