### PR TITLE
Correct color for RGB14v3 messages

### DIFF
--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_POINT14_v3.java
@@ -404,6 +404,7 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
         /* set scanner channel as current context */
 
         current_context = ((PointDataRecordPoint14)seedItem).getScannerChannel();
+        seedItem.CompressionContext = current_context;
 
         /* create and init models and decompressors */
 
@@ -449,6 +450,7 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
             }
             // switch context to current scanner channel
             current_context = scanner_channel;
+            last_item.CompressionContext = current_context;
 
             // get last for new context
             last_item = contexts[current_context].last_item;
@@ -665,7 +667,6 @@ public class LASreadItemCompressed_POINT14_v3 extends LASreadItemCompressed {
         }
 
         PointDataRecordPoint14 result = new PointDataRecordPoint14(last_item);
-        result.CompressionContext = current_context;
 
         // remember if the last point had a gps_time_change
         last_item.gps_time_change = gps_time_change;

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB14_v3.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadItemCompressed_RGB14_v3.java
@@ -133,10 +133,9 @@ public class LASreadItemCompressed_RGB14_v3 extends LASreadItemCompressed{
         if (contexts[current_context].unused)
         {
             createAndInitModelsAndDecompressors(current_context, last_item);
+            last_item = contexts[current_context].last_item;
         }
-        last_item = contexts[current_context].last_item;
     }
-
     // decompress
 
     if (changed_RGB)

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadPoint.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/LASreadPoint.java
@@ -361,7 +361,9 @@ public class LASreadPoint {
     public boolean read(PointDataRecord[] pointRecords)
     {
         int i; // unsigned
-
+        if(pointRecords.length > 0) {
+            pointRecords[0].CompressionContext = 0;
+        }
         try
         {
             if (dec != null)
@@ -407,14 +409,14 @@ public class LASreadPoint {
                 {
                     for (i = 0; i < num_readers; i++)
                     {
-                        pointRecords[i] = readers[i].read( i > 0 ? pointRecords[0].CompressionContext : 0);
+                        pointRecords[i] = readers[i].read( pointRecords[0].CompressionContext);
                     }
                 }
                 else
                 {
                     for (i = 0; i < num_readers; i++)
                     {
-                        pointRecords[i] = readers_raw[i].read(0);
+                        pointRecords[i] = readers_raw[i].read(pointRecords[0].CompressionContext);
                     }
                     if (layered_las14_compression)
                     {
@@ -429,14 +431,14 @@ public class LASreadPoint {
                         }
                         for (i = 0; i < num_readers; i++)
                         {
-                            ((LASreadItemCompressed)(readers_compressed[i])).init(pointRecords[i], i > 0 ? pointRecords[0].CompressionContext : 0);
+                            ((LASreadItemCompressed)(readers_compressed[i])).init(pointRecords[i], pointRecords[0].CompressionContext);
                         }
                     }
                     else
                     {
                         for (i = 0; i < num_readers; i++)
                         {
-                            ((LASreadItemCompressed)(readers_compressed[i])).init(pointRecords[i], i > 0 ? pointRecords[0].CompressionContext : 0);
+                            ((LASreadItemCompressed)(readers_compressed[i])).init(pointRecords[i], pointRecords[0].CompressionContext);
                         }
                         dec.init(instream);
                     }
@@ -448,7 +450,7 @@ public class LASreadPoint {
             {
                 for (i = 0; i < num_readers; i++)
                 {
-                    pointRecords[i] = readers[i].read( i > 0 ? pointRecords[0].CompressionContext : 0);
+                    pointRecords[i] = readers[i].read( pointRecords[0].CompressionContext);
                 }
             }
         }

--- a/src/main/java/com/github/mreutegg/laszip4j/laszip/PointDataRecords.java
+++ b/src/main/java/com/github/mreutegg/laszip4j/laszip/PointDataRecords.java
@@ -27,7 +27,7 @@ import java.nio.ByteOrder;
 abstract class PointDataRecord {
 
     // For internal use only
-    public int CompressionContext = 0;
+    public static int CompressionContext = 0;
 }
 
 enum ClassificationFlag


### PR DESCRIPTION
I compared the behavior with the original C++ code. 
The context object is adapted there in the LASreadItemCompressed_POINT14_v3::read and LASreadItemCompressed_POINT14_v4::init methods.

The CompressionContext seems to be the work around here since we can not adapted the context value itself. But I think this should be static.

Also the C++ code contains the following:

```
inline void LASreadItemCompressed_RGB14_v3::read(U8* item, U32& context)
{
  // get last

  U16* last_item = contexts[current_context].last_item;

  // check for context switch

  if (current_context != context)
  {
    current_context = context; // all other items use context set by POINT14 reader
    if (contexts[current_context].unused)
    {
      createAndInitModelsAndDecompressors(current_context, (U8*)last_item);
      last_item = contexts[current_context].last_item;
    }
  }
```

having both lines in the if block.

I discovered the problem by unzipping a laz file with RGB14_v3 data with both LAStools and laszip4j and seeing different color values in the resulting las file.
